### PR TITLE
Sleep between stop and start when provisioning VM

### DIFF
--- a/colima
+++ b/colima
@@ -282,6 +282,7 @@ provision_docker() (
         # reset vm for user docker group to reflect
         stage restarting VM to complete docker setup
         run limactl stop $NAME
+        sleep 2
         run limactl start $NAME
         log VM restarted
     fi


### PR DESCRIPTION
Provisioning a new VM fails to restart after installing docker:
```
[colima] 15:47:01 creating and starting VM ...
[colima] 15:47:54 provisioning VM ...
[colima] 15:47:54 provisioning docker ...
[colima] 15:47:54 provisioning docker in VM ...
[colima] 15:48:45 restarting VM to complete docker setup ...

```
This is because of the following error:
```
time="2021-09-16T15:48:45+03:00" level=info msg="Sending SIGINT to hostagent process 5892"
time="2021-09-16T15:48:45+03:00" level=info msg="Waiting for the host agent and the qemu processes to shut down"
time="2021-09-16T15:48:45+03:00" level=info msg="[hostagent] Received SIGINT, shutting down the host agent"
time="2021-09-16T15:48:46+03:00" level=info msg="[hostagent] Shutting down the host agent"
time="2021-09-16T15:48:46+03:00" level=info msg="[hostagent] Unmounting \"/Users/kkoukopoulos\""
time="2021-09-16T15:48:46+03:00" level=info msg="[hostagent] Unmounting \"/tmp/colima\""
time="2021-09-16T15:48:46+03:00" level=warning msg="[hostagent] connection to the guest agent was closed unexpectedly"
time="2021-09-16T15:48:46+03:00" level=info msg="[hostagent] Shutting down QEMU with ACPI"
time="2021-09-16T15:48:46+03:00" level=info msg="[hostagent] Sending QMP system_powerdown command"
time="2021-09-16T15:48:47+03:00" level=info msg="[hostagent] QEMU has exited"
time="2021-09-16T15:48:47+03:00" level=info msg="Using the existing instance \"colima\""
time="2021-09-16T15:48:47+03:00" level=warning msg="expected status \"Stopped\", got \"Broken\""
time="2021-09-16T15:48:47+03:00" level=fatal msg="instance \"colima\" seems running (hint: remove \"/Users/kkoukopoulos/.lima/colima/ha.pid\" if the instance is not actually running)"
```
There seems to be some race condition or whatever, and it was fixed for me by adding a two second sleep command between the stop and start commands.