### PR TITLE
Add --mount and --mount-rw option to configure additional host directories to expose  to guests (as writable).

### DIFF
--- a/colima
+++ b/colima
@@ -21,7 +21,7 @@ export DISK="60"
 export CONF_CHANGED=""
 export ENABLE_KUBERNETES=""
 declare -a MOUNTS=()
-declare -a RW_MOUNTS=()
+declare -a MOUNTS_RW=()
 
 # derived values
 vm_user() (lima whoami)
@@ -52,7 +52,7 @@ commands:
     --memory is memory in GiB. Defaults to 4.
     --disk is disk size in GiB. Defaults to 60.
     --mount is additional host directories to expose to guests.
-    --rw-mount is additional host directories to expose to guests as writable.
+    --mount-rw is additional host directories to expose to guests as writable.
 
     For verbose ouput, tail the log file "$LOG_FILE".
 
@@ -113,7 +113,7 @@ prompt() (
 
 config_file() (
     additional_mounts=""
-    for d in ${RW_MOUNTS[@]}
+    for d in ${MOUNTS_RW[@]}
     do
         additional_mounts+=$'\n'"  - location: \"${d}\""$'\n'"    writable: true"
     done
@@ -519,10 +519,10 @@ start_vm_args() {
             CONF_CHANGED="1"
             shift
             ;;
-        --rw-mount)
+        --mount-rw)
             shift
             assert_dir "$1" || exit 1
-            RW_MOUNTS+=( "$1" )
+            MOUNTS_RW+=( "$1" )
             CONF_CHANGED="1"
             shift
             ;;


### PR DESCRIPTION
Hi @abiosoft. Thanks for providing a great tool.

I added the `--mount` option because when I use Colima, I often manually modify the `mounts:` in the generated lima.yml.

### Usage

```
$ colima start --cpu 8 --memory 8 --disk 128 --mount '~/src' --mount '~/tmp'
```

---

I know that [Colima is planned to be rewritten in Go](https://github.com/abiosoft/colima#project-goal).

Even if you can't merge this pull request, I'd be happy to get your feedback on the `--mount` option 😄 