### PR TITLE
fix (colima version): remove dependency checks for the version command.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -209,33 +209,30 @@ func (c colimaApp) Status() error {
 }
 
 func (c colimaApp) Version() error {
-	name := config.Profile()
-	version := config.AppVersion()
-	fmt.Println(name, "version", version.Version)
-	fmt.Println("git commit:", version.Revision)
+	if !c.guest.Running() {
+		return nil
+	}
 
-	if c.guest.Running() {
-		containerRuntimes, err := c.currentContainerEnvironments()
-		if err != nil {
-			return err
-		}
+	containerRuntimes, err := c.currentContainerEnvironments()
+	if err != nil {
+		return err
+	}
 
-		var kube environment.Container
-		for _, cont := range containerRuntimes {
-			if cont.Name() == kubernetes.Name {
-				kube = cont
-				continue
-			}
-			fmt.Println()
-			fmt.Println("runtime:", cont.Name())
-			fmt.Println(cont.Version())
+	var kube environment.Container
+	for _, cont := range containerRuntimes {
+		if cont.Name() == kubernetes.Name {
+			kube = cont
+			continue
 		}
+		fmt.Println()
+		fmt.Println("runtime:", cont.Name())
+		fmt.Println(cont.Version())
+	}
 
-		if kube != nil && kube.Version() != "" {
-			fmt.Println()
-			fmt.Println("kubernetes")
-			fmt.Println(kube.Version())
-		}
+	if kube != nil && kube.Version() != "" {
+		fmt.Println()
+		fmt.Println(kubernetes.Name)
+		fmt.Println(kube.Version())
 	}
 
 	return nil

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+	"github.com/abiosoft/colima/app"
 	"github.com/abiosoft/colima/cmd/root"
+	"github.com/abiosoft/colima/config"
 	"github.com/spf13/cobra"
 )
 
@@ -10,8 +13,15 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "print the version of Colima",
 	Long:  `Print the version of Colima`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return newApp().Version()
+	Run: func(cmd *cobra.Command, args []string) {
+		name := config.Profile()
+		version := config.AppVersion()
+		fmt.Println(name, "version", version.Version)
+		fmt.Println("git commit:", version.Revision)
+
+		if colimaApp, err := app.New(); err == nil {
+			_ = colimaApp.Version()
+		}
 	},
 }
 


### PR DESCRIPTION
Prevent `version` command from performing a pre-run check like other commands. It is giving a false indication of a failed build in CI systems.

Signed-off-by: Abiola Ibrahim <abiola89@gmail.com>