### PR TITLE
Add cmd option to change default architecture

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -65,6 +65,9 @@ The --runtime flag is only used on initial start and ignored on subsequent start
 		if !cmd.Flag("mount").Changed {
 			startCmdArgs.VM.Mounts = current.VM.Mounts
 		}
+		if !cmd.Flag("arch").Changed {
+			startCmdArgs.VM.Arch = current.VM.Arch
+		}
 
 		log.Println("using", current.Runtime, "runtime")
 
@@ -80,6 +83,7 @@ const (
 	defaultCPU               = 2
 	defaultMemory            = 2
 	defaultDisk              = 60
+	defaultArch              = "default"
 	defaultKubernetesVersion = "v1.22.2"
 )
 
@@ -109,6 +113,7 @@ func init() {
 	startCmd.Flags().IntVarP(&startCmdArgs.VM.Memory, "memory", "m", defaultMemory, "memory in GiB")
 	startCmd.Flags().IntVarP(&startCmdArgs.VM.Disk, "disk", "d", defaultDisk, "disk size in GiB")
 	startCmd.Flags().IPSliceVarP(&startCmdArgs.VM.DNS, "dns", "n", nil, "DNS servers for the VM")
+	startCmd.Flags().StringVarP(&startCmdArgs.VM.Arch, "arch", "a", defaultArch, "architecture (aarch64 / x86_64)")
 
 	// mounts
 	startCmd.Flags().StringSliceVarP(&startCmdArgs.VM.Mounts, "mount", "v", nil, "directories to mount, suffix ':w' for writable")

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/abiosoft/colima/util/yamlutil"
-	"gopkg.in/yaml.v3"
 	"log"
 	"net"
 	"os"
 	"path/filepath"
+
+	"github.com/abiosoft/colima/util/yamlutil"
+	"gopkg.in/yaml.v3"
 )
 
 const AppName = "colima"
@@ -138,9 +139,10 @@ type Kubernetes struct {
 
 // VM is virtual machine configuration.
 type VM struct {
-	CPU    int `yaml:"cpu"`
-	Disk   int `yaml:"disk"`
-	Memory int `yaml:"memory"`
+	CPU    int    `yaml:"cpu"`
+	Disk   int    `yaml:"disk"`
+	Memory int    `yaml:"memory"`
+	Arch   string `yaml:"arch"`
 
 	// auto generated
 	SSHPort int `yaml:"-"`

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newConf(conf config.Config) (l Config, err error) {
-	l.Arch = "default"
+	l.Arch = conf.VM.Arch
 
 	l.Images = append(l.Images,
 		File{Arch: X8664, Location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"},


### PR DESCRIPTION
I added a command line option to colima to change the used architecture.

### Why?
Sometimes I have the need to run on a M1 a docker container which is only for Intel based environments build.
A ARM-based colima environment have some issues with it:

```
$ docker run --platform linux/amd64 alpine:latest uname -a
Unable to find image 'alpine:latest' locally
latest: Pulling from library/alpine
a0d0a0d46f8b: Pull complete
Digest: sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
Status: Downloaded newer image for alpine:latest
standard_init_linux.go:228: exec user process caused: exec format error
```

### After change

```
$ ./_output/colima-amd64 start -a x86_64
INFO[0000] starting colima
INFO[0000] creating and starting ...                     context=vm
INFO[0321] provisioning ...                              context=docker
INFO[0321] provisioning in VM ...                        context=docker
INFO[0484] restarting VM to complete setup ...           context=docker
INFO[0485] stopping ...                                  context=vm
INFO[0508] starting ...                                  context=vm
INFO[0622] starting ...                                  context=docker
INFO[0663] done
$ docker run --platform linux/amd64 alpine:latest uname -a
Unable to find image 'alpine:latest' locally
latest: Pulling from library/alpine
a0d0a0d46f8b: Pull complete
Digest: sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
Status: Downloaded newer image for alpine:latest
Linux d2bdff871931 5.13.0-19-generic #19-Ubuntu SMP Thu Oct 7 21:58:00 UTC 2021 x86_64 Linux
````

### Trade Off
The disk speed of the VM is quite bad compared to the native ARM environment; but I didn't speed test it yet.