### PR TITLE
Install Docker according to official documentation

### DIFF
--- a/environment/container/docker/setup.go
+++ b/environment/container/docker/setup.go
@@ -29,11 +29,7 @@ func (d dockerRuntime) setupInVM() error {
 	if err != nil {
 		return fmt.Errorf("error installing in VM: %w", err)
 	}
-	err = d.guest.Run("curl -fsSLo /tmp/docker.pem https://download.docker.com/linux/ubuntu/gpg")
-	if err != nil {
-		return fmt.Errorf("error installing in VM: %w", err)
-	}
-	err = d.guest.Run("sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg")
+	err = d.guest.Run("bash", "-c", "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg")
 	if err != nil {
 		return fmt.Errorf("error installing in VM: %w", err)
 	}


### PR DESCRIPTION
[Using the docker.io apt package](https://github.com/abiosoft/colima/blob/main/environment/container/docker/setup.go#L28) has the drawback that it is slower to update.

The [official documentation](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) describes how to install using the apt repository maintained by Docker. This repository is also updated with new releases as soon as they are published.

[Docker 20.10.10](https://github.com/moby/moby/releases/tag/v20.10.10) supports Ubuntu Impish.

See #33 