### PR TITLE
feature: Support SSH agent forwarding

### DIFF
--- a/environment/container/docker/socket.sh
+++ b/environment/container/docker/socket.sh
@@ -1,4 +1,23 @@
 #!/usr/bin/env bash
+
+ssh -p "{{.SSHPort}}" \
+    -l "{{.VMUser}}" \
+    -i ~/.lima/_config/user \
+    -o IdentitiesOnly=yes \
+    -F /dev/null \
+    -o NoHostAuthenticationForLocalhost=yes \
+    "127.0.0.1" \
+    sudo mkdir -p /run/host-services
+
+ssh -p "{{.SSHPort}}" \
+    -l "{{.VMUser}}" \
+    -i ~/.lima/_config/user \
+    -o IdentitiesOnly=yes \
+    -F /dev/null \
+    -o NoHostAuthenticationForLocalhost=yes \
+    "127.0.0.1" \
+    sudo chown {{.VMUser}}:{{.VMUser}} /run/host-services
+
 rm -rf "{{.SocketFile}}"
 ssh -p "{{.SSHPort}}" \
     -l "{{.VMUser}}" \
@@ -7,4 +26,5 @@ ssh -p "{{.SSHPort}}" \
     -F /dev/null \
     -o NoHostAuthenticationForLocalhost=yes \
     -L "{{.SocketFile}}:/var/run/docker.sock" \
+    -R "/run/host-services/ssh-auth.sock:$SSH_AUTH_SOCK" \
     -N "127.0.0.1"


### PR DESCRIPTION
I implemented a feature to support SSH agent forwarding like Docker Desktop for Mac.
https://docs.docker.com/desktop/mac/networking/#ssh-agent-forwarding

I tested this feature on a machine with Apple M1 Max processor.
```
shiota@lima-colima:~$ ssh-add -l
Could not open a connection to your authentication agent.
shiota@lima-colima:~$ SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock ssh-add -l
256 SHA256:yz69smEOak6d+q+X8I3pMtNVa/yu6kegZlVT3zRZYt8 shiota@TetsuyanoMBP.AirPort (ED25519)
```