### PR TITLE
When SSH_AUTH_SOCK is set to a socket on the host, forward that to the VM.

### DIFF
--- a/environment/container/docker/socket.go
+++ b/environment/container/docker/socket.go
@@ -3,10 +3,11 @@ package docker
 import (
 	_ "embed"
 	"fmt"
-	"github.com/abiosoft/colima/config"
-	"github.com/abiosoft/colima/util"
 	"os"
 	"path/filepath"
+
+	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/util"
 )
 
 //go:embed socket.sh
@@ -34,7 +35,11 @@ func createSocketForwardingScript(vmUser string, sshPort int) error {
 		SocketFile string
 		SSHPort    int
 		VMUser     string
-	}{SocketFile: socketSymlink(), SSHPort: sshPort, VMUser: vmUser}
+	}{
+		SocketFile: socketSymlink(),
+		SSHPort:    sshPort,
+		VMUser:     vmUser,
+	}
 
 	err := util.WriteTemplate(socketForwardingScript, scriptFile, values)
 	if err != nil {

--- a/environment/container/docker/socket.go
+++ b/environment/container/docker/socket.go
@@ -32,13 +32,15 @@ func createSocketForwardingScript(vmUser string, sshPort int) error {
 
 	// write socket script to file
 	var values = struct {
-		SocketFile string
-		SSHPort    int
-		VMUser     string
+		SocketFile  string
+		SSHPort     int
+		VMUser      string
+		SSHAuthSock string
 	}{
-		SocketFile: socketSymlink(),
-		SSHPort:    sshPort,
-		VMUser:     vmUser,
+		SocketFile:  socketSymlink(),
+		SSHPort:     sshPort,
+		VMUser:      vmUser,
+		SSHAuthSock: os.Getenv("SSH_AUTH_SOCK"),
 	}
 
 	err := util.WriteTemplate(socketForwardingScript, scriptFile, values)

--- a/environment/container/docker/socket.sh
+++ b/environment/container/docker/socket.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 #
-# Forwards docker socket from the VM to the host and, when valid, $SSH_AUTH_SOCK to /run/host-services/ssh-auth.sock
+# Forwards docker socket from the VM to the host and, when valid, {{.SSHAuthSock}} to /run/host-services/ssh-auth.sock
 
 #######################################
-# Determine whether |SSH_AUTH_SOCK| is set and pointing to a socket.
+# Determine whether {{.SSHAuthSock}} is set and pointing to a socket.
 # Globals:
-#   SSH_AUTH_SOCK
+#   None
 # Arguments:
 #   None
-# Returns: failure when $SSH_AUTH_SOCK is either not set or not a socket.
+# Returns: failure when {{.SSHAuthSock}} is either not set or not a socket.
 #######################################
 function ssh_auth_socket_is_valid() {
-  if [[ -z $SSH_AUTH_SOCK || ! -S $SSH_AUTH_SOCK ]]; then
+  if [[ -z "{{.SSHAuthSock}}" || ! -S "{{.SSHAuthSock}}" ]]; then
     return 1
   fi
 }
@@ -19,7 +19,7 @@ function ssh_auth_socket_is_valid() {
 #######################################
 # Prepare local sockets
 # Globals:
-#   SSH_AUTH_SOCK
+#   None
 # Arguments:
 #   None
 #######################################
@@ -78,7 +78,7 @@ function install_remote_host_services() {
 }
 
 #######################################
-# Ensures that the remote directory for receiving the |SSH_AUTH_SOCK| is prepared (owned by $USER)
+# Ensures that the remote directory for receiving the {{.SSHAuthSock}} is prepared (owned by $USER)
 # Globals:
 #   None
 # Arguments:
@@ -108,7 +108,7 @@ function forward_sockets() {
   )
   if ssh_auth_socket_is_valid; then
     ssh_cmd+=(
-      -R "/run/host-services/ssh-auth.sock:${SSH_AUTH_SOCK}"
+      -R "/run/host-services/ssh-auth.sock:{{.SSHAuthSock}}"
     )
   fi
 

--- a/environment/container/docker/socket.sh
+++ b/environment/container/docker/socket.sh
@@ -1,10 +1,126 @@
 #!/usr/bin/env bash
-rm -rf "{{.SocketFile}}"
-ssh -p "{{.SSHPort}}" \
-    -l "{{.VMUser}}" \
-    -i ~/.lima/_config/user \
-    -o IdentitiesOnly=yes \
-    -F /dev/null \
-    -o NoHostAuthenticationForLocalhost=yes \
-    -L "{{.SocketFile}}:/var/run/docker.sock" \
-    -N "127.0.0.1"
+#
+# Forwards docker socket from the VM to the host and, when valid, $SSH_AUTH_SOCK to /run/host-services/ssh-auth.sock
+
+#######################################
+# Determine whether |SSH_AUTH_SOCK| is set and pointing to a socket.
+# Globals:
+#   SSH_AUTH_SOCK
+# Arguments:
+#   None
+# Returns: failure when $SSH_AUTH_SOCK is either not set or not a socket.
+#######################################
+function ssh_auth_socket_is_valid() {
+  if [[ -z $SSH_AUTH_SOCK || ! -S $SSH_AUTH_SOCK ]]; then
+    return 1
+  fi
+}
+
+#######################################
+# Prepare local sockets
+# Globals:
+#   SSH_AUTH_SOCK
+# Arguments:
+#   None
+#######################################
+function prep_local_sockets() {
+  rm -rf "{{.SocketFile}}"
+}
+
+#######################################
+# Remove remote host_services directory
+# Globals:
+#   None
+# Arguments:
+#   None
+#######################################
+function rm_remote_host_services() {
+  if ! ssh_auth_socket_is_valid; then
+    return
+  fi
+
+  local -a ssh_cmd=(
+    ssh -p "{{.SSHPort}}"
+    -l "{{.VMUser}}"
+    -i ~/.lima/_config/user
+    -o IdentitiesOnly=yes
+    -F /dev/null
+    -o NoHostAuthenticationForLocalhost=yes
+    "127.0.0.1"
+    sudo rm -rf /var/run/host-services
+  )
+  "${ssh_cmd[@]}"
+}
+
+#######################################
+# Install the remote host_services directory
+# Globals:
+#   None
+# Arguments:
+#   None
+#######################################
+function install_remote_host_services() {
+  if ! ssh_auth_socket_is_valid; then
+    return
+  fi
+
+  local -a ssh_cmd=(
+    ssh -p "{{.SSHPort}}"
+    -l "{{.VMUser}}"
+    -i ~/.lima/_config/user
+    -o IdentitiesOnly=yes
+    -F /dev/null
+    -o NoHostAuthenticationForLocalhost=yes
+    "127.0.0.1"
+    sudo install -d -o "{{.VMUser}}" /var/run/host-services
+  )
+  "${ssh_cmd[@]}"
+}
+
+#######################################
+# Ensures that the remote directory for receiving the |SSH_AUTH_SOCK| is prepared (owned by $USER)
+# Globals:
+#   None
+# Arguments:
+#   None
+#######################################
+function prep_remote_sockets() {
+  rm_remote_host_services
+  install_remote_host_services
+}
+
+#######################################
+# Forward sockets docker -> local and auth -> remote
+# Globals:
+#   None
+# Arguments:
+#   None
+#######################################
+function forward_sockets() {
+  local -a ssh_cmd=(
+    ssh -p "{{.SSHPort}}"
+    -l "{{.VMUser}}"
+    -i ~/.lima/_config/user
+    -o IdentitiesOnly=yes
+    -F /dev/null
+    -o NoHostAuthenticationForLocalhost=yes
+    -L "{{.SocketFile}}:/var/run/docker.sock"
+  )
+  if ssh_auth_socket_is_valid; then
+    ssh_cmd+=(
+      -R "/run/host-services/ssh-auth.sock:${SSH_AUTH_SOCK}"
+    )
+  fi
+
+  exec "${ssh_cmd[@]}" -N "127.0.0.1"
+}
+
+function main() {
+  prep_local_sockets
+  prep_remote_sockets
+  forward_sockets
+}
+
+if ((${#BASH_SOURCE[@]} == 1)); then
+  main "$@"
+fi


### PR DESCRIPTION
This is most useful for git access, but certainly communicating with other ssh-able destinations is handy.

When creating a docker, one can pass `-e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock` to access their ssh-agent.