### PR TITLE
add documenation for installation via nix

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,6 +14,20 @@ Development Version
 brew install --HEAD colima
 ```
 
+## Nix
+
+Only stable Version
+
+```
+nix-env -i colima
+```
+
+Or using solely in a `nix-shell`
+
+```
+nix-shell -p colima
+```
+
 ## Binary
 
 Binaries are available with every release on the [releases page](https://github.com/abiosoft/colima/releases).

--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ Container runtimes on macOS (and Linux) with minimal setup.
 
 ### Installation
 
-Colima is available on Homebrew. Check [here](INSTALL.md) for other installation options.
+Colima is available on Homebrew and Nix. Check [here](INSTALL.md) for other installation options.
 
 ```
+# Homebrew
 brew install colima
+
+# Nix
+nix-env -i colima
 ```
 
-Or stay on the bleeding edge
+Or stay on the bleeding edge (only Homebrew)
 
 ```
 brew install --HEAD colima


### PR DESCRIPTION
Introduced in `nixpkgs` by https://github.com/NixOS/nixpkgs/pull/150282
findable with https://search.nixos.org/packages?channel=unstable&show=colima&from=0&size=50&sort=relevance&type=packages&query=colima.

**Note:** It will take another 5-7 days that package will appeare in `nixpkgs-unstable`. However from than it will be automatically included into the next major nix versions. 