### PR TITLE
Add GolangCI Lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Lint
+        run: make lint
+
       - name: Build
         run: go build -v ./...
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,8 +17,11 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Lint
-        run: make lint
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+            version: v1.43.0
+            args: --timeout 3m0s
 
       - name: Build
         run: go build -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .vscode/
 _output/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ GOARCH_x86_64 = amd64
 GOARCH_aarch64 = arm64
 GOARCH_arm64 = arm64
 GOARCH ?= $(shell echo "$(GOARCH_$(ARCH))")
-GOLANGCI_LINT_VER = "1.43.0"
 
 all: build 
 
@@ -28,9 +27,5 @@ install:
 	chmod +x /usr/local/bin/colima
 
 .PHONY: lint
-lint: ## Run golangci-lint
-ifneq (${GOLANGCI_LINT_VER}, "$(shell ./bin/golangci-lint version --format short 2>&1)")
-	@echo "golangci-lint missing or not version '${GOLANGCI_LINT_VER}', downloading..."
-	curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/v${GOLANGCI_LINT_VER}/install.sh" | sh -s -- -b ./bin "v${GOLANGCI_LINT_VER}"
-endif
-	./bin/golangci-lint --timeout 3m run
+lint: ## Assumes that golangci-lint is installed and in the path.  To install: https://golangci-lint.run/usage/install/
+	golangci-lint --timeout 3m run

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOARCH_x86_64 = amd64
 GOARCH_aarch64 = arm64
 GOARCH_arm64 = arm64
 GOARCH ?= $(shell echo "$(GOARCH_$(ARCH))")
+GOLANGCI_LINT_VER = "1.41.1"
 
 all: build 
 
@@ -25,3 +26,11 @@ build:
 install:
 	cp _output/binaries/colima-$(OS)-$(ARCH) /usr/local/bin/colima
 	chmod +x /usr/local/bin/colima
+
+.PHONY: lint
+lint: ## Run golangci-lint
+ifneq (${GOLANGCI_LINT_VER}, "$(shell ./bin/golangci-lint version --format short 2>&1)")
+	@echo "golangci-lint missing or not version '${GOLANGCI_LINT_VER}', downloading..."
+	curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/v${GOLANGCI_LINT_VER}/install.sh" | sh -s -- -b ./bin "v${GOLANGCI_LINT_VER}"
+endif
+	./bin/golangci-lint --timeout 3m run

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOARCH_x86_64 = amd64
 GOARCH_aarch64 = arm64
 GOARCH_arm64 = arm64
 GOARCH ?= $(shell echo "$(GOARCH_$(ARCH))")
-GOLANGCI_LINT_VER = "1.41.1"
+GOLANGCI_LINT_VER = "1.43.0"
 
 all: build 
 

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -50,7 +50,7 @@ func (c kubernetesRuntime) Running() bool {
 func (c kubernetesRuntime) runtime() string {
 	return c.guest.Get(environment.ContainerRuntimeKey)
 }
-func (c kubernetesRuntime) kubernetesVersion() string {
+func (c kubernetesRuntime) kubernetesVersion() string { //nolint:unused
 	return c.guest.Get(environment.KubernetesVersionKey)
 }
 

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -50,9 +50,6 @@ func (c kubernetesRuntime) Running() bool {
 func (c kubernetesRuntime) runtime() string {
 	return c.guest.Get(environment.ContainerRuntimeKey)
 }
-func (c kubernetesRuntime) kubernetesVersion() string {
-	return c.guest.Get(environment.KubernetesVersionKey)
-}
 
 func (c *kubernetesRuntime) Provision() error {
 	log := c.Logger()

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -50,6 +50,9 @@ func (c kubernetesRuntime) Running() bool {
 func (c kubernetesRuntime) runtime() string {
 	return c.guest.Get(environment.ContainerRuntimeKey)
 }
+func (c kubernetesRuntime) kubernetesVersion() string {
+	return c.guest.Get(environment.KubernetesVersionKey)
+}
 
 func (c *kubernetesRuntime) Provision() error {
 	log := c.Logger()

--- a/util/downloader/download.go
+++ b/util/downloader/download.go
@@ -52,11 +52,9 @@ func (d downloader) downloadFile(url string) (err error) {
 	}
 
 	// get rid of curl's initial progress bar by getting the redirect url directly.
-	downloadURL := url
-	if u, err := d.host.RunOutput("curl", "-Ls", "-o", "/dev/null", "-w", "%{url_effective}", url); err != nil {
+	downloadURL, err := d.host.RunOutput("curl", "-Ls", "-o", "/dev/null", "-w", "%{url_effective}", url)
+	if err != nil {
 		return fmt.Errorf("error retrieving redirect url: %w", err)
-	} else {
-		downloadURL = u
 	}
 
 	// ask curl to resume previous download if possible "-C -"

--- a/util/terminal/output.go
+++ b/util/terminal/output.go
@@ -122,7 +122,7 @@ func (v verboseWriter) clearScreen() {
 
 func (v *verboseWriter) updateTerm() error {
 	// no need to refresh so quickly
-	if time.Now().Sub(v.lastUpdate) < time.Second*2 {
+	if time.Since(v.lastUpdate) < time.Second*2 {
 		return nil
 	}
 	v.lastUpdate = time.Now().UTC()


### PR DESCRIPTION
* Adding GolangCI Lint for linting
* Added lint task to Makefile
* Resolved basic linting issues

## Lint Resolution

* Removed `kubernetesVersion` as it is private and used.  If desired, please indicate how it is to be used 
* `time.Since` is preferred to `time.Now().Sub` otherwise same functionality
* Likely the most controversial, The assignment of `downloadURL := u` was never used.  if err not nil, it is assigned to `u` otherwise an error is returned.  It is better and more readable in Go to not use `else` unless required, in this case, it is much more clear.

Looking forward to adding more linting rules.   I was looking for feedback on this first.
 
Signed-off-by: Ken Sipe <kensipe@gmail.com