### PR TITLE
Add Patreon Sponsor button to repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: colima


### PR DESCRIPTION
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository and #73. Sad that GitHub Sponsors is limited to a few countries, but happy to support you on Patreon 🙏