### PR TITLE
Faster nix installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Colima is available on Homebrew and Nix. Check [here](INSTALL.md) for other inst
 brew install colima
 
 # Nix
-nix-env -i colima
+nix-env -iA nixpkgs.colima
 ```
 
 Or stay on the bleeding edge (only Homebrew)


### PR DESCRIPTION
`nix-env -i colima` will search through all attrsets in Nixpkgs, whereas `-A nixpkgs.colima` will only look at the top level, which is where the package lives.

Technically on NixOS this would be `nixos.colima`, but NixOS users probably know that all too well.