### PR TITLE
docs: add documentation for MacPorts installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,6 +14,14 @@ Development Version
 brew install --HEAD colima
 ```
 
+## MacPorts
+
+Stable version
+
+```
+sudo port install colima
+```
+
 ## Nix
 
 Only stable Version

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ Container runtimes on macOS (and Linux) with minimal setup.
 
 ### Installation
 
-Colima is available on Homebrew and Nix. Check [here](INSTALL.md) for other installation options.
+Colima is available on Homebrew, MacPorts, and Nix. Check [here](INSTALL.md) for other installation options.
 
 ```
 # Homebrew
 brew install colima
+
+# MacPorts
+sudo port install colima
 
 # Nix
 nix-env -iA nixpkgs.colima


### PR DESCRIPTION
Colima is available on [MacPorts](https://ports.macports.org/port/colima/), so the relevant docs should be updated with installation instructions.