### PR TITLE
cli: report error if arguments are given for subcommands that require no arguments

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -21,6 +21,7 @@ Use with caution. This deletes everything and a startup afterwards is like the
 initial startup of Colima.
 
 If you simply want to reset the Kubernetes cluster, run 'colima kubernetes reset'.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !deleteCmdArgs.force {
 			y := cli.Prompt("are you sure you want to delete " + config.Profile().DisplayName + " and all settings")

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -34,6 +34,7 @@ var kubernetesStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "start the Kubernetes cluster",
 	Long:  `Start the Kubernetes cluster.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()
 		k, err := app.Kubernetes()
@@ -54,6 +55,7 @@ var kubernetesStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "stop the Kubernetes cluster",
 	Long:  `Stop the Kubernetes cluster.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()
 		k, err := app.Kubernetes()
@@ -73,6 +75,7 @@ var kubernetesDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "delete the Kubernetes cluster",
 	Long:  `Delete the Kubernetes cluster.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()
 		k, err := app.Kubernetes()
@@ -97,6 +100,7 @@ This resets the Kubernetes cluster and all Kubernetes objects
 will be deleted.
 
 The Kubernetes images are cached making the startup (after reset) much faster.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()
 		k, err := app.Kubernetes()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,6 +19,7 @@ var listCmd = &cobra.Command{
 	Long: `List all created instances.
 
 A new instance can be created during 'colima start' by specifying the '--profile' flag.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		instances, err := lima.Instances()
 		if err != nil {

--- a/cmd/nerdctl.go
+++ b/cmd/nerdctl.go
@@ -54,6 +54,7 @@ var nerdctlLinkFunc = func() *cobra.Command {
 		Use:   "install",
 		Short: "install nerdctl alias script on the host",
 		Long:  `Install nerdctl alias script on the host. The script will be installed at ` + nerdctlDefaultInstallPath + `.`,
+		Args: cobra.NoArgs,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			// check if /usr/local/bin is writeable and no need for sudo
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -28,6 +28,7 @@ The --runtime, --disk and --arch flags are only used on initial start and ignore
 		"  colima start --cpu 4 --memory 8 --disk 100\n" +
 		"  colima start --arch aarch64\n" +
 		"  colima start --dns 1.1.1.1 --dns 8.8.8.8",
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return newApp().Start(startCmdArgs.Config)
 	},

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,6 +10,7 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "show the status of Colima",
 	Long:  `Show the status of Colima`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return newApp().Status()
 	},

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -13,6 +13,7 @@ var stopCmd = &cobra.Command{
 
 The state of the VM is persisted at stop. A start afterwards
 should return it back to its previous state.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return newApp().Stop()
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,6 +14,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "print the version of Colima",
 	Long:  `Print the version of Colima`,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		version := config.AppVersion()
 		fmt.Println(config.AppName, "version", version.Version)


### PR DESCRIPTION
I use Colima conveniently every day. Thank you.

When I have multiple profiles, I have deleted the environment several times by running the following command by mistake.

```console
$ colima list
PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK
default    Running    aarch64    8       8GiB      128GiB
x64        Running    x86_64     8       8GiB      128GiB
$ # I want to delete `x64` profile !!
$ colima delete x64 # !!!???
are you sure you want to delete colima and all settings? [y/N] y
INFO[0015] deleting colima
INFO[0015] deleting ...                                  context=docker
INFO[0015] deleting ...                                  context=vm
INFO[0015] done
$ colima list 
PROFILE    STATUS     ARCH      CPUS    MEMORY    DISK
x64        Running    x86_64    8       8GiB      128GiB
$ # Oh. I missed.
```

This pull request is a fix to make error if arguments are given for subcommands that require no arguments.

```console
$ make build
GOOS=darwin GOARCH=arm64 OS=Darwin ARCH=arm64 sh scripts/build.sh
++ git describe --tags --always
+ VERSION=v0.1.10-121-g853634a
++ git rev-parse HEAD
+ REVISION=853634a97fcdb97d8827dc18626002341f11df98
+ PACKAGE=github.com/abiosoft/colima/config
+ OUTPUT_DIR=_output/binaries
+ mkdir -p _output/binaries
+ OUTPUT_BIN=colima-Darwin-arm64
+ go build -ldflags '-X github.com/abiosoft/colima/config.appVersion=v0.1.10-121-g853634a -X github.com/abiosoft/colima/config.revision=853634a97fcdb97d8827dc18626002341f11df98' -o _outp
ut/binaries/colima-Darwin-arm64 ./cmd/colima
+ SHA256SUM=sha256sum
+ [[ darwin21 == \d\a\r\w\i\n* ]]
+ SHA256SUM='shasum -a 256'
+ cd _output/binaries
+ shasum -a 256 colima-Darwin-arm64
$ ./_output/binaries/colima-Darwin-arm64 list
PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK
default    Running    aarch64    8       8GiB      128GiB
x64        Running    x86_64     8       8GiB      128GiB
$ ./_output/binaries/colima-Darwin-arm64 delete x64
Error: unknown command "x64" for "colima delete"
Usage:
  colima delete [flags]

Flags:
  -f, --force   do not prompt for yes/no
  -h, --help    help for delete

Global Flags:
  -p, --profile string   profile name, for multiple instances (default "default")
      --verbose          enable verbose log

FATA[0000] unknown command "x64" for "colima delete"
$
```

