### PR TITLE
Make k3s version configurable

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -83,10 +83,10 @@ The --runtime, --disk and --arch flags are only used on initial start and ignore
 }
 
 const (
-	defaultCPU               = 2
-	defaultMemory            = 2
-	defaultDisk              = 60
-	defaultKubernetesVersion = "v1.22.2"
+	defaultCPU        = 2
+	defaultMemory     = 2
+	defaultDisk       = 60
+	defaultK3sVersion = "v1.22.4+k3s1"
 )
 
 var startCmdArgs struct {
@@ -112,9 +112,7 @@ func init() {
 
 	// k8s
 	startCmd.Flags().BoolVarP(&startCmdArgs.Kubernetes.Enabled, "with-kubernetes", "k", false, "start VM with Kubernetes")
-	startCmd.Flags().StringVar(&startCmdArgs.Kubernetes.Version, "kubernetes-version", defaultKubernetesVersion, "the Kubernetes version")
-	// not so familiar with k3s versioning atm, hide for now.
-	_ = startCmd.Flags().MarkHidden("kubernetes-version")
+	startCmd.Flags().StringVar(&startCmdArgs.Kubernetes.Version, "kubernetes-version", defaultK3sVersion, "the Kubernetes (https://k3s.io) version")
 
 	// not sure of the usefulness of env vars for now considering that interactions will be with the containers, not the VM.
 	// leaving it undocumented until there is a need.

--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -12,8 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const k3sVersion = "v1.22.4+k3s1"
-
 func installK3s(host environment.HostActions, guest environment.GuestActions, a *cli.ActiveCommandChain, log *logrus.Entry, containerRuntime string) {
 	installK3sBinary(host, guest, a)
 	installK3sCache(host, guest, a, log, containerRuntime)
@@ -23,7 +21,7 @@ func installK3s(host environment.HostActions, guest environment.GuestActions, a 
 func installK3sBinary(host environment.HostActions, guest environment.GuestActions, a *cli.ActiveCommandChain) {
 	// install k3s last to ensure it is the last step
 	downloadPath := "/tmp/k3s"
-	url := "https://github.com/k3s-io/k3s/releases/download/" + k3sVersion + "/k3s"
+	url := "https://github.com/k3s-io/k3s/releases/download/" + guest.Get(environment.KubernetesVersionKey) + "/k3s"
 	if guest.Arch().GoArch() == "arm64" {
 		url += "-arm64"
 	}
@@ -40,7 +38,7 @@ func installK3sCache(host environment.HostActions, guest environment.GuestAction
 	imageTarGz := imageTar + ".gz"
 	downloadPathTar := "/tmp/" + imageTar
 	downloadPathTarGz := "/tmp/" + imageTarGz
-	url := "https://github.com/k3s-io/k3s/releases/download/" + k3sVersion + "/" + imageTarGz
+	url := "https://github.com/k3s-io/k3s/releases/download/" + guest.Get(environment.KubernetesVersionKey) + "/" + imageTarGz
 	a.Add(func() error {
 		return downloader.Download(host, guest, url, downloadPathTarGz)
 	})
@@ -84,7 +82,7 @@ func installK3sCache(host environment.HostActions, guest environment.GuestAction
 func installK3sCluster(host environment.HostActions, guest environment.GuestActions, a *cli.ActiveCommandChain, containerRuntime string) {
 	// install k3s last to ensure it is the last step
 	downloadPath := "/tmp/k3s-install.sh"
-	url := "https://raw.githubusercontent.com/k3s-io/k3s/" + k3sVersion + "/install.sh"
+	url := "https://raw.githubusercontent.com/k3s-io/k3s/" + guest.Get(environment.KubernetesVersionKey) + "/install.sh"
 	a.Add(func() error {
 		return downloader.Download(host, guest, url, downloadPath)
 	})


### PR DESCRIPTION
Fixes https://github.com/abiosoft/colima/issues/46

Previously there was a hidden --kubernetes-version flag that was ignored. This commit plumbs it through to the version of k3s that is installed. I noticed in https://github.com/abiosoft/colima/issues/46 there was some talk of automatically detecting k3s versions (presumably to always install the latest version by default?). That functionality would be handy, but in the meantime I feel this PR is a step in the right direction, as it makes it _possible_ to select a different version rather than having it hardcoded.

Now, when I don't supply a version I see the same behavior I used to (i.e. k3s v1.22.x is installed).

```console
$ ./_output/binaries/colima-Darwin-arm64 start --runtime containerd --with-kubernetes -c 4 -m 4
INFO[0000] starting colima                              
INFO[0000] creating and starting ...                     context=vm
INFO[0021] starting ...                                  context=containerd
INFO[0026] waiting for startup to complete ...           context=containerd
INFO[0027] downloading and installing ...                context=kubernetes
INFO[0032] loading oci images ...                        context=kubernetes
> unpacking docker.io/rancher/mirrored-library-busybox:1.32.1 (sha256:6b23544141396cd3a36fa1b3ed3ccade0d30068c1802bbae64eef1e3e5ab9d54)...done
> unpacking docker.io/rancher/mirrored-library-traefik:2.5.0 (sha256:8a718325f4c589a2e44688ae87f74dab4c64648431ab9457dee9aa96aad93354)...done
> unpacking docker.io/rancher/mirrored-metrics-server:v0.5.0 (sha256:1a89693d2093a62715e24714fcc88f980c144fe2a769531c62a487cd1dcd5b3c)...ctr: failed to resolve rootfs: content digest sha256:ee11f1e38ac66c96e91e9504296e77a57733101b02a678
WARN[0034] error loading oci images: exit status 1       context=kubernetes
WARN[0034] startup may delay a bit as images will be pulled from oci registry  context=kubernetes
INFO[0034] starting ...                                  context=kubernetes
INFO[0039] updating config ...                           context=kubernetes
INFO[0040] Switched to context "colima".                 context=kubernetes
INFO[0040] done                                         

$ ./_output/binaries/colima-Darwin-arm64 ssh
colima:/Users/negz/control/abiosoft/colima$ k3s --version
k3s version v1.22.4+k3s1 (bec170bc)
go version go1.16.10
```

However, when I supply the `--kubernetes-version` flag I can pick a different K3S version:

```console
$ ./_output/binaries/colima-Darwin-arm64 start --runtime containerd --with-kubernetes --kubernetes-version v1.23.4+k3s1 -c 4 -m 4
INFO[0000] starting colima                              
INFO[0000] creating and starting ...                     context=vm
INFO[0021] starting ...                                  context=containerd
INFO[0026] waiting for startup to complete ...           context=containerd
INFO[0026] downloading and installing ...                context=kubernetes
INFO[0037] loading oci images ...                        context=kubernetes
> unpacking docker.io/rancher/local-path-provisioner:v0.0.21 (sha256:7d89362db230fd1178ba9465bc3582b09872ee6be72037e2ad80cf812751299e)...done
> unpacking docker.io/rancher/mirrored-coredns-coredns:1.8.6 (sha256:a6d8488c231616918f517bd33321ade37f6b55e9355450cbf512d053e4df505e)...ctr: failed to resolve rootfs: content digest sha256:edaa71f2aee883484133da046954ad70fd6bf1fa42e5ae
WARN[0039] error loading oci images: exit status 1       context=kubernetes
WARN[0039] startup may delay a bit as images will be pulled from oci registry  context=kubernetes
INFO[0040] starting ...                                  context=kubernetes
INFO[0045] updating config ...                           context=kubernetes
INFO[0046] Switched to context "colima".                 context=kubernetes
INFO[0046] done                                         

$ ./_output/binaries/colima-Darwin-arm64 ssh
colima:/Users/negz/control/abiosoft/colima$ k3s --version
k3s version v1.23.4+k3s1 (43b1cb48)
go version go1.17.5
```