### PR TITLE
kubernetes: prevent port forward conflicts for apiserver

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -33,6 +33,8 @@ type HostActions interface {
 	WithEnv(env ...string) HostActions
 	// Env retrieves environment variable on the host.
 	Env(string) string
+	// Port finds a random, unused port on the host.
+	Port() (int, error)
 }
 
 // GuestActions are actions performed on the guest i.e. VM.

--- a/environment/host/host.go
+++ b/environment/host/host.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -110,6 +111,17 @@ func (h hostEnv) Write(fileName, body string) error {
 
 func (h hostEnv) Stat(fileName string) (os.FileInfo, error) {
 	return os.Stat(fileName)
+}
+
+func (h hostEnv) Port() (int, error) {
+	l, err := net.Listen("tcp4", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = l.Close()
+	}()
+	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // IsInstalled checks if dependencies are installed.


### PR DESCRIPTION
Pick a random free port on the host and use that as the value for
the `--https-listen-port` argument for k3s.

This makes it possible to create multiple colima profiles/instances
with Kubernetes; otherwise, they'll all be listening on 6443, and
only the first one will be port forwarded, so attempting to use any
others will result in x509 errors since the config<>cluster mapping
is erroneous.