### PR TITLE
vm: propagate upstream support for mountPoint

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -237,12 +237,17 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 		if err != nil {
 			return err
 		}
-		for _, m := range conf.Mounts {
-			location, err := util.CleanPath(m.Location)
+		for _, m := range conf.MountsOrDefault() {
+			location := m.MountPoint
+			if location == "" {
+				location = m.Location
+			}
+			location, err := util.CleanPath(location)
 			if err != nil {
+				log.Trace(err)
 				continue
 			}
-			if strings.HasPrefix(location, pwd) {
+			if strings.HasPrefix(pwd, location) {
 				return nil
 			}
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -222,8 +222,45 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 		return fmt.Errorf("%s not running", config.CurrentProfile().DisplayName)
 	}
 
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error retrieving current working directory: %w", err)
+	}
+	// peek the current directory to see if it is mounted to prevent `cd` errors
+	// with limactl ssh
+	if err := func() error {
+		conf, err := limautil.InstanceConfig()
+		if err != nil {
+			return err
+		}
+		pwd, err := util.CleanPath(workDir)
+		if err != nil {
+			return err
+		}
+		for _, m := range conf.Mounts {
+			location, err := util.CleanPath(m.Location)
+			if err != nil {
+				continue
+			}
+			if strings.HasPrefix(location, pwd) {
+				return nil
+			}
+		}
+		return fmt.Errorf("not a mounted directory: %s", workDir)
+	}(); err != nil {
+		// the errors returned here is not critical and thereby silenced.
+		// the goal is to prevent unecessary warning message from Lima.
+		log.Trace(fmt.Errorf("error checking if PWD is mounted: %w", err))
+
+		// fallback to the user's homedir
+		username, err := c.guest.User()
+		if err == nil {
+			workDir = "/home/" + username + ".linux"
+		}
+	}
+
 	if !layer {
-		return c.guest.RunInteractive(args...)
+		return c.guest.SSH(workDir, args...)
 	}
 
 	conf, err := limautil.InstanceConfig()
@@ -231,7 +268,7 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 		return err
 	}
 	if !conf.Layer {
-		return c.guest.RunInteractive(args...)
+		return c.guest.SSH(workDir, args...)
 	}
 
 	resp, err := limautil.ShowSSH(config.CurrentProfile().ID, layer, "args")
@@ -244,15 +281,10 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 
 	cmdArgs := resp.Output
 
-	wd, err := os.Getwd()
-	if err != nil {
-		log.Debug(fmt.Errorf("cannot get working dir: %w", err))
-	}
-
 	if len(args) > 0 {
 		args = append([]string{"-q", "-t", resp.IPAddress, "--"}, args...)
-	} else if wd != "" {
-		args = []string{"-q", "-t", resp.IPAddress, "--", "cd " + wd + " 2> /dev/null; bash --login"}
+	} else if workDir != "" {
+		args = []string{"-q", "-t", resp.IPAddress, "--", "cd " + workDir + " 2> /dev/null; bash --login"}
 	}
 
 	args = append(util.ShellSplit(cmdArgs), args...)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -156,11 +157,21 @@ func init() {
 func mountsFromFlag(mounts []string) []config.Mount {
 	mnts := make([]config.Mount, len(mounts))
 	for i, mount := range mounts {
-		str := strings.SplitN(mount, ":", 2)
-		mnts[i] = config.Mount{
-			Location: str[0],
-			Writable: len(str) >= 2 && str[1] == "w",
+		str := strings.SplitN(mount, ":", 3)
+		mnt := config.Mount{Location: str[0]}
+
+		if len(str) > 1 {
+			if filepath.IsAbs(str[1]) {
+				mnt.MountPoint = str[1]
+			} else if str[1] == "w" {
+				mnt.Writable = true
+			}
 		}
+		if len(str) > 2 && str[2] == "w" {
+			mnt.Writable = true
+		}
+
+		mnts[i] = mnt
 	}
 	return mnts
 }

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -39,6 +39,17 @@ func Test_mountsFromFlag(t *testing.T) {
 				{Location: "/tmp"},
 			},
 		},
+		{
+			mounts: []string{
+				"/home/users:/home/users", "/home/another:w", "/tmp:/users/tmp", "/tmp:/users/tmp:w",
+			},
+			want: []config.Mount{
+				{Location: "/home/users", MountPoint: "/home/users"},
+				{Location: "/home/another", Writable: true},
+				{Location: "/tmp", MountPoint: "/users/tmp"},
+				{Location: "/tmp", MountPoint: "/users/tmp", Writable: true},
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -112,8 +112,9 @@ type Network struct {
 
 // Mount is volume mount
 type Mount struct {
-	Location string `yaml:"location"`
-	Writable bool   `yaml:"writable"`
+	Location   string `yaml:"location"`
+	MountPoint string `yaml:"mountPoint,omitempty"`
+	Writable   bool   `yaml:"writable"`
 }
 
 // CleanPath returns the absolute path to the mount location.

--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,7 @@
 package config
 
 import (
-	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -115,23 +113,6 @@ type Mount struct {
 	Location   string `yaml:"location"`
 	MountPoint string `yaml:"mountPoint,omitempty"`
 	Writable   bool   `yaml:"writable"`
-}
-
-// CleanPath returns the absolute path to the mount location.
-func (m Mount) CleanPath() (string, error) {
-	split := strings.SplitN(m.Location, ":", 2)
-	str := os.ExpandEnv(split[0])
-
-	if strings.HasPrefix(str, "~") {
-		str = strings.Replace(str, "~", util.HomeDir(), 1)
-	}
-
-	str = filepath.Clean(str)
-	if !filepath.IsAbs(str) {
-		return "", fmt.Errorf("relative paths not supported for mount '%s'", m.Location)
-	}
-
-	return strings.TrimSuffix(str, "/") + "/", nil
 }
 
 func (c Config) MountsOrDefault() []Mount {

--- a/environment/container/ubuntu/provision.go
+++ b/environment/container/ubuntu/provision.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/util"
 )
 
 type buildArgs struct {
@@ -150,7 +151,16 @@ func (u ubuntuRuntime) createContainer(conf config.Config) error {
 
 	mounts := conf.MountsOrDefault()
 	for _, m := range mounts {
-		args = append(args, "--volume", m.Location+":"+m.Location)
+		location := m.MountPoint
+		if location == "" {
+			location = m.Location
+		}
+
+		location, err := util.CleanPath(location)
+		if err != nil {
+			return err
+		}
+		args = append(args, "--volume", location+":"+location)
 	}
 
 	env := conf.Env

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -49,6 +49,8 @@ type GuestActions interface {
 	Stop(ctx context.Context, force bool) error
 	// Restart restarts the VM
 	Restart(ctx context.Context) error
+	// SSH performs an ssh connection to the VM
+	SSH(workingDir string, args ...string) error
 	// Created returns if the VM has been previously created.
 	Created() bool
 	// Running returns if the VM is currently running.

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -349,6 +349,18 @@ func (l limaVM) Run(args ...string) error {
 	return a.Exec()
 }
 
+func (l limaVM) SSH(workingDir string, args ...string) error {
+	args = append([]string{limactl, "shell", "--workdir", workingDir, config.CurrentProfile().ID}, args...)
+
+	a := l.Init(context.Background())
+
+	a.Add(func() error {
+		return l.host.RunInteractive(args...)
+	})
+
+	return a.Exec()
+}
+
 func (l limaVM) RunInteractive(args ...string) error {
 	args = append([]string{lima}, args...)
 

--- a/environment/vm/lima/limautil/limautil.go
+++ b/environment/vm/lima/limautil/limautil.go
@@ -288,6 +288,7 @@ func ubuntuSSHPort(profileID string) (int, error) {
 	var buf bytes.Buffer
 	cmd := cli.Command("limactl", "shell", profileID, "--", "sh", "-c", "echo $"+LayerEnvVar)
 	cmd.Stdout = &buf
+	cmd.Stderr = nil
 
 	if err := cmd.Run(); err != nil {
 		return 0, fmt.Errorf("cannot retrieve ubuntu layer SSH port: %w", err)

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -275,13 +275,17 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 		cacheOverlapFound := false
 
 		for _, m := range conf.Mounts {
-			var location string
-			location, err = m.CleanPath()
+			var location, mountPoint string
+			location, err = util.CleanPath(m.Location)
+			if err != nil {
+				return
+			}
+			mountPoint, err = util.CleanPath(m.MountPoint)
 			if err != nil {
 				return
 			}
 
-			mount := Mount{Location: location, MountPoint: m.MountPoint, Writable: m.Writable}
+			mount := Mount{Location: location, MountPoint: mountPoint, Writable: m.Writable}
 
 			// use passthrough for readonly 9p mounts
 			if conf.MountType == NINEP && !m.Writable {
@@ -417,12 +421,12 @@ type NineP struct {
 func checkOverlappingMounts(mounts []config.Mount) error {
 	for i := 0; i < len(mounts)-1; i++ {
 		for j := i + 1; j < len(mounts); j++ {
-			a, err := mounts[i].CleanPath()
+			a, err := util.CleanPath(mounts[i].Location)
 			if err != nil {
 				return err
 			}
 
-			b, err := mounts[j].CleanPath()
+			b, err := util.CleanPath(mounts[j].Location)
 			if err != nil {
 				return err
 			}

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -281,7 +281,7 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 				return
 			}
 
-			mount := Mount{Location: location, Writable: m.Writable}
+			mount := Mount{Location: location, MountPoint: m.MountPoint, Writable: m.Writable}
 
 			// use passthrough for readonly 9p mounts
 			if conf.MountType == NINEP && !m.Writable {
@@ -333,9 +333,10 @@ type File struct {
 }
 
 type Mount struct {
-	Location string `yaml:"location"` // REQUIRED
-	Writable bool   `yaml:"writable"`
-	NineP    NineP  `yaml:"9p,omitempty" json:"9p,omitempty"`
+	Location   string `yaml:"location"` // REQUIRED
+	MountPoint string `yaml:"mountPoint,omitempty"`
+	Writable   bool   `yaml:"writable"`
+	NineP      NineP  `yaml:"9p,omitempty" json:"9p,omitempty"`
 }
 
 type SSH struct {

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -73,4 +74,25 @@ func ShellSplit(cmd string) []string {
 	}
 
 	return split
+}
+
+// CleanPath returns the absolute path to the mount location.
+// If location is an empty string, nothing is done.
+func CleanPath(location string) (string, error) {
+	if location == "" {
+		return "", nil
+	}
+
+	str := os.ExpandEnv(location)
+
+	if strings.HasPrefix(str, "~") {
+		str = strings.Replace(str, "~", HomeDir(), 1)
+	}
+
+	str = filepath.Clean(str)
+	if !filepath.IsAbs(str) {
+		return "", fmt.Errorf("relative paths not supported for mount '%s'", location)
+	}
+
+	return strings.TrimSuffix(str, "/") + "/", nil
 }


### PR DESCRIPTION
Add support for specifying `mountPoint` for mounted folders, a feature already in Lima but not utilised.

## Usage

### CLI

```
colima start --mount /src/folder:/dest/folder:w
```

### Config

```yaml
mounts:
  - location: ~/secrets
    mountPoint: /custom/secrets
    writable: true
```
