### PR TITLE
util: prevent division by zero in printScreen

### DIFF
--- a/util/terminal/output.go
+++ b/util/terminal/output.go
@@ -137,6 +137,13 @@ func (v *verboseWriter) updateTerm() error {
 	if err != nil {
 		return fmt.Errorf("error getting terminal size: %w", err)
 	}
+	// A width of zero would result in a division by zero panic when computing overflow
+	// in printScreen. Therefore, set it to a safe - even though probably wrong - value.
+	// We use <= 0 here because negative values are guaranteed to lead to unexpected
+	// results, even if they don't cause panics.
+	if w <= 0 {
+		w = 80
+	}
 	v.termWidth = w
 
 	return nil


### PR DESCRIPTION
Observed the following when running colima in a terminal with somehow garbled settings (`stty size` printing `0 0`):
```
$ colima start
INFO[0000] starting colima                              
INFO[0000] runtime: docker                              
INFO[0000] preparing network ...                         context=vm
INFO[0000] creating and starting ...                     context=vm
panic: runtime error: integer divide by zero

goroutine 25 [running]:
github.com/abiosoft/colima/util/terminal.(*verboseWriter).printScreen(0xc000172fc0)
        github.com/abiosoft/colima/util/terminal/output.go:115 +0x1b3
github.com/abiosoft/colima/util/terminal.(*verboseWriter).refresh(0xc000172fc0)
        github.com/abiosoft/colima/util/terminal/output.go:65 +0x92
github.com/abiosoft/colima/util/terminal.(*verboseWriter).Write(0xc000172fc0, {0xc00030c000, 0x72, 0x0?})
        github.com/abiosoft/colima/util/terminal/output.go:48 +0x8c
io.copyBuffer({0x279f558, 0xc000172fc0}, {0x17cf2c0, 0xc000122338}, {0x0, 0x0, 0x0})
        io/io.go:428 +0x204
io.Copy(...)
        io/io.go:385
os/exec.(*Cmd).writerDescriptor.func1()
        os/exec/exec.go:311 +0x3a
os/exec.(*Cmd).Start.func1(0x0?)
        os/exec/exec.go:444 +0x25
created by os/exec.(*Cmd).Start
        os/exec/exec.go:443 +0x795
```

While we can't expect the output to look particularly good in such an environment, the tool should at least not panic, obscuring whether or not an action succeeded.