### PR TITLE
feat: add disable-servicelb flag

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -145,6 +145,7 @@ func init() {
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.LegacyKubernetes, "with-kubernetes", false, "start with Kubernetes")
 	startCmd.Flags().StringVar(&startCmdArgs.Kubernetes.Version, "kubernetes-version", defaultKubernetesVersion, "must match a k3s version https://github.com/k3s-io/k3s/releases")
 	startCmd.Flags().BoolVar(&startCmdArgs.Kubernetes.Ingress, "kubernetes-ingress", false, "enable Traefik ingress controller")
+	startCmd.Flags().BoolVar(&startCmdArgs.Kubernetes.ServiceLB, "kubernetes-servicelb", true, "enable service LB controller")
 	startCmd.Flag("with-kubernetes").Hidden = true
 
 	// layer

--- a/config/config.go
+++ b/config/config.go
@@ -8,8 +8,10 @@ import (
 	"github.com/abiosoft/colima/util"
 )
 
-const AppName = "colima"
-const SubprocessProfileEnvVar = "COLIMA_PROFILE"
+const (
+	AppName                 = "colima"
+	SubprocessProfileEnvVar = "COLIMA_PROFILE"
+)
 
 var profile = ProfileInfo{ID: AppName, DisplayName: AppName, ShortName: "default"}
 
@@ -100,9 +102,10 @@ type Config struct {
 
 // Kubernetes is kubernetes configuration
 type Kubernetes struct {
-	Enabled bool   `yaml:"enabled"`
-	Version string `yaml:"version"`
-	Ingress bool   `yaml:"ingress"`
+	Enabled   bool   `yaml:"enabled"`
+	Version   string `yaml:"version"`
+	Ingress   bool   `yaml:"ingress"`
+	ServiceLB bool   `yaml:"servicelb"`
 }
 
 // Network is VM network configuration

--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -21,10 +21,11 @@ func installK3s(host environment.HostActions,
 	containerRuntime string,
 	k3sVersion string,
 	ingress bool,
+	servicelb bool,
 ) {
 	installK3sBinary(host, guest, a, k3sVersion)
 	installK3sCache(host, guest, a, log, containerRuntime, k3sVersion)
-	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, ingress)
+	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, ingress, servicelb)
 }
 
 func installK3sBinary(
@@ -97,7 +98,6 @@ func installK3sCache(
 			return nil
 		})
 	}
-
 }
 
 func installK3sCluster(
@@ -107,6 +107,7 @@ func installK3sCluster(
 	containerRuntime string,
 	k3sVersion string,
 	ingress bool,
+	servicelb bool,
 ) {
 	// install k3s last to ensure it is the last step
 	downloadPath := "/tmp/k3s-install.sh"
@@ -125,6 +126,9 @@ func installK3sCluster(
 
 	if !ingress {
 		args = append(args, "--disable", "traefik")
+	}
+	if !servicelb {
+		args = append(args, "--disable", "servicelb")
 	}
 
 	// replace ip address if networking is enabled
@@ -146,5 +150,4 @@ func installK3sCluster(
 	a.Add(func() error {
 		return guest.Run("sh", "-c", "INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_SKIP_ENABLE=true k3s-install.sh "+strings.Join(args, " "))
 	})
-
 }

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -51,6 +51,7 @@ func (c kubernetesRuntime) isInstalled() bool {
 	// it is installed if uninstall script is present.
 	return c.guest.RunQuiet("command", "-v", "k3s-uninstall.sh") == nil
 }
+
 func (c kubernetesRuntime) isVersionInstalled(version string) bool {
 	// validate version change via cli flag/config.
 	out, err := c.guest.RunOutput("k3s", "--version")
@@ -110,7 +111,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 			installK3sCache(c.host, c.guest, a, log, runtime, conf.Version)
 		}
 		// other settings may have changed e.g. ingress
-		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.Ingress)
+		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.Ingress, conf.ServiceLB)
 	} else {
 		if c.isInstalled() {
 			a.Stagef("version changed to %s, downloading and installing", conf.Version)
@@ -121,7 +122,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 				a.Stage("installing")
 			}
 		}
-		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.Ingress)
+		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.Ingress, conf.ServiceLB)
 	}
 
 	// this needs to happen on each startup
@@ -198,7 +199,6 @@ func (c kubernetesRuntime) deleteAllContainers() error {
 }
 
 func (c kubernetesRuntime) stopAllContainers() error {
-
 	ids := c.runningContainerIDs()
 	if ids == "" {
 		return nil


### PR DESCRIPTION
This PR adds a `kubernetes-servicelb` flag which controls whether to enable service LB in k3s.

This is just a proposal. Ideally we'd introduce a mechanism which would allow to control all the "features" of k3s (as indicated below) via e.g. a slice of strings (flags at the CLI level) which would then be added as `--disable-FEATURE` to k3s server invocation

```
   --disable value                            (components) Do not deploy packaged components and delete any deployed components (valid items: coredns, servicelb, traefik, local-storage, metrics-server)
```

That would though be a breaking change if we wanted to make it consistent and move the ingress controller knob there as well.

Let me know what you think!