### PR TITLE
vm: multiple minor fixes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -118,7 +118,7 @@ func (c colimaApp) Start(conf config.Config) error {
 
 	log.Println("done")
 
-	if err := generateSSHConfig(); err != nil {
+	if err := generateSSHConfig(conf.SSHConfig); err != nil {
 		log.Trace("error generating ssh_config: %w", err)
 	}
 	return nil
@@ -162,7 +162,7 @@ func (c colimaApp) Stop(force bool) error {
 
 	log.Println("done")
 
-	if err := generateSSHConfig(); err != nil {
+	if err := generateSSHConfig(false); err != nil {
 		log.Trace("error generating ssh_config: %w", err)
 	}
 	return nil
@@ -209,7 +209,7 @@ func (c colimaApp) Delete() error {
 
 	log.Println("done")
 
-	if err := generateSSHConfig(); err != nil {
+	if err := generateSSHConfig(false); err != nil {
 		log.Trace("error generating ssh_config: %w", err)
 	}
 	return nil
@@ -430,7 +430,7 @@ func (c colimaApp) Active() bool {
 	return c.guest.Running(context.Background())
 }
 
-func generateSSHConfig() error {
+func generateSSHConfig(modifySSHConfig bool) error {
 	instances, err := limautil.Instances()
 	if err != nil {
 		return fmt.Errorf("error retrieving instances: %w", err)
@@ -461,6 +461,11 @@ func generateSSHConfig() error {
 	sshFileColima := filepath.Join(filepath.Dir(config.Dir()), "ssh_config")
 	if err := os.WriteFile(sshFileColima, buf.Bytes(), 0644); err != nil {
 		return fmt.Errorf("error writing ssh_config file: %w", err)
+	}
+
+	if !modifySSHConfig {
+		// ~/.ssh/config modification disabled
+		return nil
 	}
 
 	includeLine := "Include " + sshFileColima

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -228,6 +228,9 @@ func prepareConfig(cmd *cobra.Command) {
 	if !cmd.Flag("kubernetes").Changed {
 		startCmdArgs.Kubernetes.Enabled = current.Kubernetes.Enabled
 	}
+	if !cmd.Flag("kubernetes-version").Changed {
+		startCmdArgs.Kubernetes.Version = current.Kubernetes.Version
+	}
 	if !cmd.Flag("runtime").Changed {
 		startCmdArgs.Runtime = current.Runtime
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -140,6 +140,9 @@ func init() {
 	// ssh agent
 	startCmd.Flags().BoolVarP(&startCmdArgs.ForwardAgent, "ssh-agent", "s", false, "forward SSH agent to the VM")
 
+	// ssh config generation
+	startCmd.Flags().BoolVar(&startCmdArgs.SSHConfig, "ssh-config", true, "generate SSH config in ~/.ssh/config")
+
 	// k8s
 	startCmd.Flags().BoolVarP(&startCmdArgs.Kubernetes.Enabled, "kubernetes", "k", false, "start with Kubernetes")
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.LegacyKubernetes, "with-kubernetes", false, "start with Kubernetes")
@@ -245,6 +248,9 @@ func prepareConfig(cmd *cobra.Command) {
 	}
 	if !cmd.Flag("ssh-agent").Changed {
 		startCmdArgs.ForwardAgent = current.ForwardAgent
+	}
+	if !cmd.Flag("ssh-config").Changed {
+		startCmdArgs.SSHConfig = current.SSHConfig
 	}
 	if !cmd.Flag("dns").Changed {
 		startCmdArgs.Network.DNS = current.Network.DNS

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,9 @@ type Config struct {
 
 	// provision scripts
 	Provision []Provision `yaml:"provision,omitempty"`
+
+	// SSH config generation
+	SSHConfig bool `yaml:"sshConfig,omitempty"`
 }
 
 // Kubernetes is kubernetes configuration

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -133,6 +133,11 @@ layer: false
 # Default: []
 provision: []
 
+# Modify ~/.ssh/config automatically to include a SSH config for the virtual machine.
+# SSH config will still be generated in ~/.colima/ssh_config regardless.
+# Default: true
+sshConfig: true
+
 # Configure volume mounts for the virtual machine.
 # Colima mounts user's home directory by default to provide a familiar
 # user experience.

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	Name           = "kubernetes"
-	DefaultVersion = "v1.25.0+k3s1"
+	DefaultVersion = "v1.25.2+k3s1"
 
 	configKey = "kubernetes_config"
 )

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -275,7 +275,7 @@ func (l limaVM) Running(ctx context.Context) bool {
 func (l limaVM) Stop(ctx context.Context, force bool) error {
 	log := l.Logger(ctx)
 	a := l.Init(ctx)
-	if !l.Running(ctx) {
+	if !l.Running(ctx) && !force {
 		log.Println("not running")
 		return nil
 	}


### PR DESCRIPTION
vm: allow user to disable auto ssh config generation. Fixes #441 
k3s: fix Kubernetes version not persisting. Fixes #417 
vm: ignore running status when stopping and `--force` is passed. Fixes #439 
