### PR TITLE
feat: add kubernetes-disable flag

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -148,7 +148,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&startCmdArgs.Kubernetes.Enabled, "kubernetes", "k", false, "start with Kubernetes")
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.LegacyKubernetes, "with-kubernetes", false, "start with Kubernetes")
 	startCmd.Flags().StringVar(&startCmdArgs.Kubernetes.Version, "kubernetes-version", defaultKubernetesVersion, "must match a k3s version https://github.com/k3s-io/k3s/releases")
-	startCmd.Flags().StringSliceVar(&startCmdArgs.Kubernetes.Disable, "kubernetes-disable", nil, "a slice of packaged component names to disable when running with k3s (default empty)")
+	startCmd.Flags().StringSliceVar(&startCmdArgs.Kubernetes.Disable, "kubernetes-disable", nil, "components to disable for k3s e.g. traefik,servicelb (default empty)")
 	startCmd.Flag("with-kubernetes").Hidden = true
 
 	// layer

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -37,7 +37,8 @@ Run 'colima template' to set the default configurations or 'colima start --edit'
 		"  colima start --runtime containerd --kubernetes\n" +
 		"  colima start --cpu 4 --memory 8 --disk 100\n" +
 		"  colima start --arch aarch64\n" +
-		"  colima start --dns 1.1.1.1 --dns 8.8.8.8",
+		"  colima start --dns 1.1.1.1 --dns 8.8.8.8\n" +
+		"  colima start --kubernetes --kubernetes-disable=coredns,servicelb,traefik,local-storage,metrics-server",
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()
@@ -147,7 +148,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&startCmdArgs.Kubernetes.Enabled, "kubernetes", "k", false, "start with Kubernetes")
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.LegacyKubernetes, "with-kubernetes", false, "start with Kubernetes")
 	startCmd.Flags().StringVar(&startCmdArgs.Kubernetes.Version, "kubernetes-version", defaultKubernetesVersion, "must match a k3s version https://github.com/k3s-io/k3s/releases")
-	startCmd.Flags().BoolVar(&startCmdArgs.Kubernetes.Ingress, "kubernetes-ingress", false, "enable Traefik ingress controller")
+	startCmd.Flags().StringSliceVar(&startCmdArgs.Kubernetes.Disable, "kubernetes-disable", nil, "a slice of packaged component names to disable when running with k3s (default empty)")
 	startCmd.Flag("with-kubernetes").Hidden = true
 
 	// layer

--- a/config/config.go
+++ b/config/config.go
@@ -8,8 +8,10 @@ import (
 	"github.com/abiosoft/colima/util"
 )
 
-const AppName = "colima"
-const SubprocessProfileEnvVar = "COLIMA_PROFILE"
+const (
+	AppName                 = "colima"
+	SubprocessProfileEnvVar = "COLIMA_PROFILE"
+)
 
 var profile = ProfileInfo{ID: AppName, DisplayName: AppName, ShortName: "default"}
 
@@ -103,9 +105,9 @@ type Config struct {
 
 // Kubernetes is kubernetes configuration
 type Kubernetes struct {
-	Enabled bool   `yaml:"enabled"`
-	Version string `yaml:"version"`
-	Ingress bool   `yaml:"ingress"`
+	Enabled bool     `yaml:"enabled"`
+	Version string   `yaml:"version"`
+	Disable []string `yaml:"disable"`
 }
 
 // Network is VM network configuration

--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -20,11 +20,11 @@ func installK3s(host environment.HostActions,
 	log *logrus.Entry,
 	containerRuntime string,
 	k3sVersion string,
-	ingress bool,
+	disable []string,
 ) {
 	installK3sBinary(host, guest, a, k3sVersion)
 	installK3sCache(host, guest, a, log, containerRuntime, k3sVersion)
-	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, ingress)
+	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, disable)
 }
 
 func installK3sBinary(
@@ -97,7 +97,6 @@ func installK3sCache(
 			return nil
 		})
 	}
-
 }
 
 func installK3sCluster(
@@ -106,7 +105,7 @@ func installK3sCluster(
 	a *cli.ActiveCommandChain,
 	containerRuntime string,
 	k3sVersion string,
-	ingress bool,
+	disable []string,
 ) {
 	// install k3s last to ensure it is the last step
 	downloadPath := "/tmp/k3s-install.sh"
@@ -123,8 +122,8 @@ func installK3sCluster(
 		"--resolv-conf", "/etc/resolv.conf",
 	}
 
-	if !ingress {
-		args = append(args, "--disable", "traefik")
+	for _, d := range disable {
+		args = append(args, "--disable", d)
 	}
 
 	// replace ip address if networking is enabled
@@ -146,5 +145,4 @@ func installK3sCluster(
 	a.Add(func() error {
 		return guest.Run("sh", "-c", "INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_SKIP_ENABLE=true k3s-install.sh "+strings.Join(args, " "))
 	})
-
 }

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -51,6 +51,7 @@ func (c kubernetesRuntime) isInstalled() bool {
 	// it is installed if uninstall script is present.
 	return c.guest.RunQuiet("command", "-v", "k3s-uninstall.sh") == nil
 }
+
 func (c kubernetesRuntime) isVersionInstalled(version string) bool {
 	// validate version change via cli flag/config.
 	out, err := c.guest.RunOutput("k3s", "--version")
@@ -110,7 +111,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 			installK3sCache(c.host, c.guest, a, log, runtime, conf.Version)
 		}
 		// other settings may have changed e.g. ingress
-		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.Ingress)
+		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.Disable)
 	} else {
 		if c.isInstalled() {
 			a.Stagef("version changed to %s, downloading and installing", conf.Version)
@@ -121,7 +122,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 				a.Stage("installing")
 			}
 		}
-		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.Ingress)
+		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.Disable)
 	}
 
 	// this needs to happen on each startup
@@ -198,7 +199,6 @@ func (c kubernetesRuntime) deleteAllContainers() error {
 }
 
 func (c kubernetesRuntime) stopAllContainers() error {
-
 	ids := c.runningContainerIDs()
 	if ids == "" {
 		return nil

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -165,7 +165,7 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 
 		// disable ports 80 and 443 when k8s is enabled and there is a reachable IP address
 		// to prevent ingress (traefik) from occupying relevant host ports.
-		if reachableIPAddress && conf.Kubernetes.Enabled && conf.Kubernetes.Ingress {
+		if reachableIPAddress && conf.Kubernetes.Enabled && !disableHas(conf.Kubernetes.Disable, "ingress") {
 			l.PortForwards = append(l.PortForwards,
 				PortForward{
 					GuestIP:           net.ParseIP("0.0.0.0"),
@@ -439,4 +439,14 @@ func checkOverlappingMounts(mounts []config.Mount) error {
 		}
 	}
 	return nil
+}
+
+// disableHas checks if the provided feature is indeed found in the disable configuration slice.
+func disableHas(disable []string, feature string) bool {
+	for _, f := range disable {
+		if f == feature {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR adds a generic `--kubernetes-disable` flag which accepts a slice of names of packaged k3s components to disable.

Full list of those can be obtained by looking at the flags for `k3s server`:

```
   --disable value                            (components) Do not deploy packaged components and delete any deployed components (valid items: coredns, servicelb, traefik, local-storage, metrics-server)
```