### PR TITLE
fix: when vm /etc/hosts contains empty line could cause index out of range

### DIFF
--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -492,7 +492,7 @@ func includesHost(hostsFileContent, host string, ip net.IP) bool {
 	scanner := bufio.NewScanner(strings.NewReader(hostsFileContent))
 	for scanner.Scan() {
 		str := strings.Fields(scanner.Text())
-		if str[0] != ip.String() {
+		if len(str) == 0 || str[0] != ip.String() {
 			continue
 		}
 		if len(str) > 1 && str[1] == host {


### PR DESCRIPTION
RT

error log: 
```
INFO[0000] starting colima                              
INFO[0000] runtime: docker                              
INFO[0000] preparing network ...                         context=vm
INFO[0000] starting ...                                  context=vm
panic: runtime error: index out of range [0] with length 0
  
goroutine 1 [running]:
github.com/abiosoft/colima/environment/vm/lima.includesHost({0xc000010900, 0xfb}, {0x1760f0f, 0x14}, {0xc0000bfe60, 0x10, 0x10})
        github.com/abiosoft/colima/environment/vm/lima/lima.go:495 +0x216

```