### PR TITLE
template: save default config from template

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -63,6 +63,11 @@ var templateCmd = &cobra.Command{
 
 		log.Println("configurations template saved")
 
+		// save to default config file
+		if err := configmanager.SaveToFile(cf, config.File()); err != nil {
+			return fmt.Errorf("error saving default: %w", err)
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
I found colima can not update the default config when I run `colima template`.
E.g.,
I change the kubernetes version in the template by running `colima tempalte`
<img width="678" alt="image" src="https://user-images.githubusercontent.com/105263896/202676412-b2f54be2-c6be-4571-9271-4d8b982dc356.png">
but the version in the default config does not change when I run `colima start --edit`
<img width="687" alt="image" src="https://user-images.githubusercontent.com/105263896/202676625-ad462a14-c0b6-4793-8d06-c20b9074e29a.png">

This PR fixes it.