### PR TITLE
ci: upgrade golangci-lint GitHub action package from v2 to v3

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: 1.18
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.48.0
           args: --timeout 3m0s


### PR DESCRIPTION
This change will resolve the warnings for usage GitHub actions deprecated commands `save-state` in golangci-lint workflow.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Austin Vazquez <macedonv@amazon.com>