### PR TITLE
fix: persist kubernetes config

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,6 +115,11 @@ func (c colimaApp) Start(conf config.Config) error {
 	// persist the current runtime
 	if err := c.setRuntime(conf.Runtime); err != nil {
 		log.Error(fmt.Errorf("error persisting runtime settings: %w", err))
+	}
+
+	// persist the kubernetes config
+	if err := c.setKubernetes(conf.Kubernetes); err != nil {
+		log.Error(fmt.Errorf("error persisting kubernetes settings: %w", err))
 	}
 
 	log.Println("done")
@@ -388,6 +394,15 @@ func (c colimaApp) currentRuntime(ctx context.Context) (string, error) {
 
 func (c colimaApp) setRuntime(runtime string) error {
 	return c.guest.Set(environment.ContainerRuntimeKey, runtime)
+}
+
+func (c colimaApp) setKubernetes(conf config.Kubernetes) error {
+	b, err := json.Marshal(conf)
+	if err != nil {
+		return err
+	}
+
+	return c.guest.Set(kubernetes.ConfigKey, string(b))
 }
 
 func (c colimaApp) currentContainerEnvironments(ctx context.Context) ([]environment.Container, error) {

--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -122,6 +122,9 @@ func installK3sCluster(
 		"--resolv-conf", "/etc/resolv.conf",
 	}
 
+	// disable traefik defaults
+	args = append(args, "--disable", "traefik")
+
 	for _, d := range disable {
 		args = append(args, "--disable", d)
 	}

--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -122,9 +122,6 @@ func installK3sCluster(
 		"--resolv-conf", "/etc/resolv.conf",
 	}
 
-	// disable traefik defaults
-	args = append(args, "--disable", "traefik")
-
 	for _, d := range disable {
 		args = append(args, "--disable", d)
 	}

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -20,7 +20,7 @@ const (
 	Name           = "kubernetes"
 	DefaultVersion = "v1.25.4+k3s1"
 
-	configKey = "kubernetes_config"
+	ConfigKey = "kubernetes_config"
 )
 
 func newRuntime(host environment.HostActions, guest environment.GuestActions) environment.Container {
@@ -71,7 +71,7 @@ func (c kubernetesRuntime) runtime() string {
 
 func (c kubernetesRuntime) config() config.Kubernetes {
 	conf := config.Kubernetes{Version: DefaultVersion}
-	if b := c.guest.Get(configKey); b != "" {
+	if b := c.guest.Get(ConfigKey); b != "" {
 		_ = json.Unmarshal([]byte(b), &conf)
 	}
 	return conf
@@ -83,7 +83,7 @@ func (c kubernetesRuntime) setConfig(conf config.Kubernetes) error {
 		return fmt.Errorf("error encoding kubernetes config to json: %w", err)
 	}
 
-	return c.guest.Set(configKey, string(b))
+	return c.guest.Set(ConfigKey, string(b))
 }
 
 func (c *kubernetesRuntime) Provision(ctx context.Context) error {


### PR DESCRIPTION
## TL; DR

This PR fixes an issue that the traefik component is still launched even it is disabled by default in the `colima.yaml` config.

## Issue Description

On starting colima with kubernetes disabled, the kubernetes config is not persisted to the filesystem of the guest OS. Later we start the kubernetes and it failed to load the kubernetes config. As a side effect, it still launches the traefik component even it is disabled by default.

## Solution

- Persist the kubernetes config to the filesystem of guest OS on starting colima
~~- Add traefik to the default disabled component list~~