### PR TITLE
fix: detect macos version

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -115,7 +115,7 @@ func init() {
 
 	defaultMountType := "9p"
 	defaultVMType := "qemu"
-	if util.MacOS13() {
+	if util.MacOS13OrNewer() {
 		defaultVMType = "vz"
 		defaultMountType = "virtiofs"
 	}
@@ -136,7 +136,7 @@ func init() {
 	if util.MacOS() {
 		startCmd.Flags().BoolVar(&startCmdArgs.Network.Address, "network-address", false, "assign reachable IP address to the VM")
 	}
-	if util.MacOS13() {
+	if util.MacOS13OrNewer() {
 		startCmd.Flags().StringVarP(&startCmdArgs.VMType, "vm-type", "t", defaultVMType, "virtual machine type ("+types+")")
 	}
 
@@ -297,7 +297,7 @@ func prepareConfig(cmd *cobra.Command) {
 		if !cmd.Flag("network-address").Changed {
 			startCmdArgs.Network.Address = current.Network.Address
 		}
-		if util.MacOS13() {
+		if util.MacOS13OrNewer() {
 			if !cmd.Flag("vm-type").Changed {
 				startCmdArgs.VMType = current.VMType
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -159,7 +159,7 @@ func CtxKey() any {
 }
 
 func (c Config) DriverLabel() string {
-	if util.MacOS13() && c.VMType == "vz" {
+	if util.MacOS13OrNewer() && c.VMType == "vz" {
 		return "macOS Virtualization.Framework"
 	}
 	return "QEMU"

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -27,10 +27,10 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 	l.VMType = QEMU
 
 	sameArchitecture := environment.HostArch() == l.Arch
-	isM1 := util.MacOS13() && environment.HostArch() == environment.AARCH64
+	isM1 := util.MacOS13OrNewer() && environment.HostArch() == environment.AARCH64
 
 	// when vz is chosen and OS version supports it
-	if util.MacOS13() && conf.VMType == VZ && sameArchitecture {
+	if util.MacOS13OrNewer() && conf.VMType == VZ && sameArchitecture {
 		l.VMType = VZ
 
 		// Rosetta is only available on M1

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -27,14 +27,13 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 	l.VMType = QEMU
 
 	sameArchitecture := environment.HostArch() == l.Arch
-	isM1 := util.MacOS13OrNewer() && environment.HostArch() == environment.AARCH64
 
 	// when vz is chosen and OS version supports it
 	if util.MacOS13OrNewer() && conf.VMType == VZ && sameArchitecture {
 		l.VMType = VZ
 
 		// Rosetta is only available on M1
-		if isM1 {
+		if l.Arch == environment.AARCH64 {
 			l.Rosetta.Enabled = true
 			l.Rosetta.BinFmt = true
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -46,7 +46,7 @@ func MacOS13OrNewer() bool {
 		return false
 	}
 
-	return cver.Equal(*ver) || cver.LessThan(*ver)
+	return cver.Compare(*ver) <= 0
 }
 
 // AppendToPath appends directory to PATH.

--- a/util/util.go
+++ b/util/util.go
@@ -29,8 +29,8 @@ func MacOS() bool {
 	return runtime.GOOS == "darwin"
 }
 
-// MacOS13 returns if the current OS is macOS 13 or newer.
-func MacOS13() bool {
+// MacOS13OrNewer returns if the current OS is macOS 13 or newer.
+func MacOS13OrNewer() bool {
 	if !MacOS() {
 		return false
 	}


### PR DESCRIPTION
## Changes

- rename `MacOS13OrNewer` to make the function more readable
- decrease the number of calling version comparison
- disable duplicated macOS version check in case of M1