### PR TITLE
dns: support for custom hosts

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -212,6 +212,9 @@ func prepareConfig(cmd *cobra.Command) {
 	startCmdArgs.Mounts = mountsFromFlag(startCmdArgs.Flags.Mounts)
 	startCmdArgs.ActivateRuntime = &startCmdArgs.Flags.ActivateRuntime
 
+	// host resolver only in config file
+	startCmdArgs.HostResolver = current.HostResolver
+
 	// handle macOS virtualization.framework transition
 	{
 		if current.VMType == "" {

--- a/config/config.go
+++ b/config/config.go
@@ -104,9 +104,6 @@ type Config struct {
 
 	// SSH config generation
 	SSHConfig bool `yaml:"sshConfig,omitempty"`
-
-	// dns resolver configuration
-	HostResolver HostResolver `yaml:"hostResolver,omitempty"`
 }
 
 // Kubernetes is kubernetes configuration
@@ -118,8 +115,9 @@ type Kubernetes struct {
 
 // Network is VM network configuration
 type Network struct {
-	Address bool     `yaml:"address"`
-	DNS     []net.IP `yaml:"dns"`
+	Address      bool              `yaml:"address"`
+	DNSResolvers []net.IP          `yaml:"dns"`
+	DNSHosts     map[string]string `yaml:"dns_hosts"`
 }
 
 // Mount is volume mount
@@ -132,12 +130,6 @@ type Mount struct {
 type Provision struct {
 	Mode   string `yaml:"mode"`
 	Script string `yaml:"script"`
-}
-
-type HostResolver struct {
-	Enabled bool              `yaml:"enabled,omitempty"`
-	IPv6    bool              `yaml:"ipv6,omitempty"`
-	Hosts   map[string]string `yaml:"hosts,omitempty"`
 }
 
 func (c Config) MountsOrDefault() []Mount {

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,9 @@ type Config struct {
 
 	// SSH config generation
 	SSHConfig bool `yaml:"sshConfig,omitempty"`
+
+	// dns resolver configuration
+	HostResolver HostResolver `yaml:"hostResolver,omitempty"`
 }
 
 // Kubernetes is kubernetes configuration
@@ -129,6 +132,12 @@ type Mount struct {
 type Provision struct {
 	Mode   string `yaml:"mode"`
 	Script string `yaml:"script"`
+}
+
+type HostResolver struct {
+	Enabled bool              `yaml:"enabled,omitempty"`
+	IPv6    bool              `yaml:"ipv6,omitempty"`
+	Hosts   map[string]string `yaml:"hosts,omitempty"`
 }
 
 func (c Config) MountsOrDefault() []Mount {

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -169,3 +169,15 @@ mounts: []
 #
 # Default: {}
 env: {}
+
+# Host resolver configuration for the virtual machine.
+#
+# EXAMPLE
+# hostResolver:
+#   enabled: true
+#   hosts:
+#     example.com: 1.2.3.4
+hostResolver:
+  enabled: true
+  hosts:
+    host.docker.internal: host.lima.internal

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -61,6 +61,12 @@ network:
   # Default: []
   dns: []
 
+  # DNS hostnames to resolve to custom targets using the internal Lima resolver.
+  # This setting has no effect if a custom DNS resolver list is supplied above.
+  # It does not configure the /etc/hosts files of any machine or container.
+  dns_hosts:
+    host.docker.internal: host.lima.internal
+
 # ===================================================================== #
 # ADVANCED CONFIGURATION
 # ===================================================================== #
@@ -169,15 +175,3 @@ mounts: []
 #
 # Default: {}
 env: {}
-
-# Host resolver configuration for the virtual machine.
-#
-# EXAMPLE
-# hostResolver:
-#   enabled: true
-#   hosts:
-#     example.com: 1.2.3.4
-hostResolver:
-  enabled: true
-  hosts:
-    host.docker.internal: host.lima.internal

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -62,10 +62,16 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 	l.SSH = SSH{LocalPort: 0, LoadDotSSHPubKeys: false, ForwardAgent: conf.ForwardAgent}
 	l.Containerd = Containerd{System: false, User: false}
 
-	l.DNS = conf.Network.DNS
-	l.HostResolver.Enabled = conf.HostResolver.Enabled
-	l.HostResolver.IPv6 = conf.HostResolver.IPv6
-	l.HostResolver.Hosts = conf.HostResolver.Hosts
+	l.DNS = conf.Network.DNSResolvers
+	l.HostResolver.Enabled = len(conf.Network.DNSResolvers) == 0
+	l.HostResolver.Hosts = conf.Network.DNSHosts
+	if l.HostResolver.Hosts == nil {
+		l.HostResolver.Hosts = make(map[string]string)
+	}
+
+	if _, ok := l.HostResolver.Hosts["host.docker.internal"]; !ok {
+		l.HostResolver.Hosts["host.docker.internal"] = "host.lima.internal"
+	}
 
 	l.Env = conf.Env
 	if l.Env == nil {

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -63,10 +63,9 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 	l.Containerd = Containerd{System: false, User: false}
 
 	l.DNS = conf.Network.DNS
-	l.HostResolver.Enabled = len(l.DNS) == 0
-	l.HostResolver.Hosts = map[string]string{
-		"host.docker.internal": "host.lima.internal",
-	}
+	l.HostResolver.Enabled = conf.HostResolver.Enabled
+	l.HostResolver.IPv6 = conf.HostResolver.IPv6
+	l.HostResolver.Hosts = conf.HostResolver.Hosts
 
 	l.Env = conf.Env
 	if l.Env == nil {

--- a/util/yamlutil/yaml_test.go
+++ b/util/yamlutil/yaml_test.go
@@ -12,7 +12,7 @@ import (
 func Test_encode_Docker(t *testing.T) {
 	conf := config.Config{
 		Docker:     map[string]any{"insecure-registries": []any{"127.0.0.1"}},
-		Network:    config.Network{DNS: []net.IP{net.ParseIP("1.1.1.1")}},
+		Network:    config.Network{DNSResolvers: []net.IP{net.ParseIP("1.1.1.1")}},
 		Kubernetes: config.Kubernetes{Disable: []string{"treafik"}},
 	}
 


### PR DESCRIPTION
This PR adds support for passing host resolver information to Lima, allowing the internal DNS resolver to resolve any custom names you wish. This is particularly useful for services that do not use `getaddrinfo`, ie. specific nginx, envoy configurations.