### PR TITLE
cli: add --version flag

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -9,11 +9,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var versionInfo = config.AppVersion()
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "colima",
-	Short: "container runtimes on macOS with minimal setup",
-	Long:  `Colima provides container runtimes on macOS with minimal setup.`,
+	Use:     "colima",
+	Short:   "container runtimes on macOS with minimal setup",
+	Long:    `Colima provides container runtimes on macOS with minimal setup.`,
+	Version: versionInfo.Version,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 
 		switch cmd.Name() {


### PR DESCRIPTION
I instinctively type `colima --version` because that works for almost all binaries, especially golang binaries, and it's easy to add with cobra.

This just adds the Version member of the root cobra.Command so we get `colima --version`.

```
$ _output/binaries/colima-Darwin-arm64  --version
colima version v0.5.2
```