### PR TITLE
cli: basic validation of config flags and config file, fixes #548

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,13 @@ on:
       - "**/*.md"
       - "**/*.nix"
       - "**/*.lock"
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Debug with tmate set "debug_enabled"'
+        required: false
+        default: "false"
+
 jobs:
   kubernetes-docker:
     runs-on: macos-12
@@ -31,6 +38,13 @@ jobs:
 
       - name: Build and Install
         run: make && sudo make install
+
+      - name: tmate debugging session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
       - name: Start Colima
         run: colima start --runtime docker --kubernetes

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,6 +75,13 @@ jobs:
       - name: Build and Install
         run: make && sudo make install
 
+      - name: tmate debugging session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
       - name: Start
         run: colima start --runtime containerd --kubernetes
 
@@ -103,6 +110,13 @@ jobs:
 
       - name: Build and Install
         run: make && sudo make install
+
+      - name: tmate debugging session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
       - name: Start Colima
         run: colima start --runtime docker
@@ -154,6 +168,13 @@ jobs:
       - name: Build and Install
         run: make && sudo make install
 
+      - name: tmate debugging session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
       - name: Start Colima
         run: colima start --runtime docker --arch aarch64
 
@@ -204,6 +225,13 @@ jobs:
       - name: Build and Install
         run: make && sudo make install
 
+      - name: tmate debugging session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
       - name: Start Colima
         run: colima start --runtime containerd
 
@@ -250,6 +278,13 @@ jobs:
 
       - name: Build and Install
         run: make && sudo make install
+
+      - name: tmate debugging session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
       - name: Start Colima
         run: colima start --runtime containerd --arch aarch64

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -221,6 +221,7 @@ func mountsFromFlag(mounts []string) []config.Mount {
 }
 
 func setDefaults(cmd *cobra.Command) {
+	startCmdArgs.VMType = "qemu"
 	if util.MacOS13OrNewer() {
 		// changing to vz implies changing mount type to virtiofs
 		if cmd.Flag("vm-type").Changed && startCmdArgs.VMType == "vz" && !cmd.Flag("mount-type").Changed {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -44,6 +44,10 @@ Run 'colima template' to set the default configurations or 'colima start --edit'
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()
 		conf := startCmdArgs.Config
+		err := configmanager.ValidateConfig(conf)
+		if err != nil {
+			return err
+		}
 
 		if !startCmdArgs.Flags.Edit {
 			if app.Active() {
@@ -54,7 +58,7 @@ Run 'colima template' to set the default configurations or 'colima start --edit'
 		}
 
 		// edit flag is specified
-		err := editConfigFile()
+		err = editConfigFile()
 		if err != nil {
 			return err
 		}

--- a/config/configmanager/config.go
+++ b/config/configmanager/config.go
@@ -2,6 +2,7 @@ package configmanager
 
 import (
 	"fmt"
+	"github.com/abiosoft/colima/util"
 	"os"
 	"path/filepath"
 
@@ -68,11 +69,17 @@ func ValidateConfig(c config.Config) error {
 		return fmt.Errorf("invalid networkDriver: '%s'", c.Network.Driver)
 	}
 
-	validMountTypes := map[string]bool{"9p": true, "sshfs": true, "virtiofs": true}
+	validMountTypes := map[string]bool{"9p": true, "sshfs": true}
+	if util.MacOS13OrNewer() {
+		validMountTypes["virtiofs"] = true
+	}
 	if _, ok := validMountTypes[c.MountType]; !ok {
 		return fmt.Errorf("invalid mountType: '%s'", c.MountType)
 	}
-	validVMTypes := map[string]bool{"qemu": true, "vz": true}
+	validVMTypes := map[string]bool{"qemu": true}
+	if util.MacOS13OrNewer() {
+		validVMTypes["vz"] = true
+	}
 	if _, ok := validVMTypes[c.VMType]; !ok {
 		return fmt.Errorf("invalid vmType: '%s'", c.VMType)
 	}

--- a/config/configmanager/config.go
+++ b/config/configmanager/config.go
@@ -50,7 +50,34 @@ func LoadFrom(file string) (config.Config, error) {
 	if err != nil {
 		return c, fmt.Errorf("could not load config from file: %w", err)
 	}
+
+	err = ValidateConfig(c)
+	if err != nil {
+		return c, err
+	}
 	return c, nil
+}
+
+// ValidateConfig validates config before we use it
+func ValidateConfig(c config.Config) error {
+
+	// cpuType validation dependent on qemu; harder to do here
+
+	validnetworkDrivers := map[string]bool{"gvproxy": true, "slirp": true}
+	if _, ok := validnetworkDrivers[c.Network.Driver]; !ok {
+		return fmt.Errorf("invalid networkDriver: '%s'", c.Network.Driver)
+	}
+
+	validMountTypes := map[string]bool{"9p": true, "sshfs": true, "virtiofs": true}
+	if _, ok := validMountTypes[c.MountType]; !ok {
+		return fmt.Errorf("invalid mountType: '%s'", c.MountType)
+	}
+	validVMTypes := map[string]bool{"qemu": true, "vz": true}
+	if _, ok := validVMTypes[c.VMType]; !ok {
+		return fmt.Errorf("invalid vmType: '%s'", c.VMType)
+	}
+
+	return nil
 }
 
 // Load loads the config.


### PR DESCRIPTION
This is a start at config validation for
* #548

It's as far as I'll get right now, but it's a start. I'd rather add tests and such, but think I'll be lost on it for too long.

**Note that this does not allow empty values in config for vm-type, network-driver, mount-type, and those were previously allowed, but seemed to have unusual results in many cases.**

```
$ _output/binaries/colima-Darwin-arm64 start -p c --vm-type=xxx
FATA[0000] invalid vmType: 'xxx'

$ _output/binaries/colima-Darwin-arm64 start -p c --mount-type=xxx
WARN[0000] config load failed: invalid vmType: 'xxx'
WARN[0000] reverting to default settings
FATA[0000] invalid mountType: 'xxx'

# With mountType set to yyy in config file:
$ _output/binaries/colima-Darwin-arm64 start -p c
WARN[0000] config load failed: invalid mountType: 'yyy'
WARN[0000] reverting to default settings
FATA[0000] invalid mountType: 'yyy'
```

I'm sure you have preferences of other ways to do a bit of this, and I'm fine with going a different direction.

Edit: This adds [tmate action](https://github.com/mxschmitt/action-tmate) to the integration tests, which allows you to ssh  into a test and manually interact with it. You can't use it until it goes into main branch, after that you would start it with the actions menu, https://github.com/abiosoft/colima/actions/workflows/integration.yml - and use the "Run Workflow" button:

<img width="771" alt="Actions_·_rfay_colima" src="https://user-images.githubusercontent.com/112444/210156590-9b2c5e1e-f959-46f2-a16e-3d7cb02d2387.png">


