### PR TITLE
docs: update README for Rosetta 2 emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Or by editing the config file with `colima start --edit`.
   colima start --cpu 4 --memory 8
   ```
 
+- create VM with Rosetta 2 emulation (for MacOS Ventura)
+
+  ```
+  colima start --arch aarch64 --vm-type=vz --vz-rosetta
+  ```
+
 ## Project Goal
 
 To provide container runtimes on macOS with minimal setup.


### PR DESCRIPTION
Hi, I came across this project today and it's great, thank you!

It took me a while to figure out why `--vm-type=vz` wasn't using Rosetta by default in my Mac until I found the latest #555 PR.

Just updating a small bit in the docs in case it's useful for others. 

Thanks.