### PR TITLE
docker: set host-gateway-ip to loopback interface

### DIFF
--- a/environment/container/docker/daemon.go
+++ b/environment/container/docker/daemon.go
@@ -24,6 +24,11 @@ func (d dockerRuntime) createDaemonFile(conf map[string]any) error {
 		conf["exec-opts"] = append(opts, "native.cgroupdriver=cgroupfs")
 	}
 
+	// set host-gateway ip to loopback interface (if not set by user)
+	if _, ok := conf["host-gateway"]; !ok {
+		conf["host-gateway-ip"] = "192.168.5.2"
+	}
+
 	b, err := json.MarshalIndent(conf, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling daemon.json: %w", err)


### PR DESCRIPTION
This PR intends to improve compatibility with docker desktop to simplify migration to colima.

https://docs.docker.com/engine/reference/commandline/dockerd/

> --host-gateway-ip ip 
> IP address that the special 'host-gateway' string in --add-host resolves to. Defaults to the IP address of the default bridge

Docker desktop sets this setting to `192.168.65.2` which is loopback address for vpnkit.

Fixes https://github.com/abiosoft/colima/issues/277