### PR TITLE
cli: add more details to status command

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -341,8 +341,10 @@ func (c colimaApp) Status(extended bool) error {
 		log.Println("kubernetes: enabled")
 	}
 
-	// additional instance details
+	// additional details
 	if extended {
+		log.Println("networkDriver:", conf.Network.Driver)
+
 		if inst, err := limautil.Instance(); err == nil {
 			log.Println("cpu:", inst.CPU)
 			log.Println("mem:", units.BytesSize(float64(inst.Memory)))

--- a/app/app.go
+++ b/app/app.go
@@ -31,7 +31,7 @@ type App interface {
 	Stop(force bool) error
 	Delete() error
 	SSH(layer bool, args ...string) error
-	Status() error
+	Status(extended bool) error
 	Version() error
 	Runtime() (string, error)
 	Kubernetes() (environment.Container, error)
@@ -302,7 +302,7 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 	return cli.CommandInteractive("ssh", args...).Run()
 }
 
-func (c colimaApp) Status(full bool) error {
+func (c colimaApp) Status(extended bool) error {
 	ctx := context.Background()
 	if !c.guest.Running(ctx) {
 		return fmt.Errorf("%s is not running", config.CurrentProfile().DisplayName)
@@ -341,11 +341,13 @@ func (c colimaApp) Status(full bool) error {
 		log.Println("kubernetes: enabled")
 	}
 
-	// instance details
-	if inst, err := limautil.Instance(); err == nil {
-		log.Println("cpu:", inst.CPU)
-		log.Println("mem:", units.BytesSize(float64(inst.Memory)))
-		log.Println("disk: ", units.BytesSize(float64(inst.Disk)))
+	// additional instance details
+	if extended {
+		if inst, err := limautil.Instance(); err == nil {
+			log.Println("cpu:", inst.CPU)
+			log.Println("mem:", units.BytesSize(float64(inst.Memory)))
+			log.Println("disk:", units.BytesSize(float64(inst.Disk)))
+		}
 	}
 
 	return nil

--- a/app/app.go
+++ b/app/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/abiosoft/colima/environment/vm/lima"
 	"github.com/abiosoft/colima/environment/vm/lima/limautil"
 	"github.com/abiosoft/colima/util"
+	"github.com/docker/go-units"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -301,7 +302,7 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 	return cli.CommandInteractive("ssh", args...).Run()
 }
 
-func (c colimaApp) Status() error {
+func (c colimaApp) Status(full bool) error {
 	ctx := context.Background()
 	if !c.guest.Running(ctx) {
 		return fmt.Errorf("%s is not running", config.CurrentProfile().DisplayName)
@@ -338,6 +339,13 @@ func (c colimaApp) Status() error {
 	// kubernetes
 	if k, err := c.Kubernetes(); err == nil && k.Running(ctx) {
 		log.Println("kubernetes: enabled")
+	}
+
+	// instance details
+	if inst, err := limautil.Instance(); err == nil {
+		log.Println("cpu:", inst.CPU)
+		log.Println("mem:", units.BytesSize(float64(inst.Memory)))
+		log.Println("disk: ", units.BytesSize(float64(inst.Disk)))
 	}
 
 	return nil

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,6 +5,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var statusCmdArgs struct {
+	extended bool
+}
+
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
 	Use:   "status [profile]",
@@ -12,10 +16,12 @@ var statusCmd = &cobra.Command{
 	Long:  `Show the status of Colima`,
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return newApp().Status()
+		return newApp().Status(statusCmdArgs.extended)
 	},
 }
 
 func init() {
 	root.Cmd().AddCommand(statusCmd)
+
+	statusCmd.Flags().BoolVarP(&statusCmdArgs.extended, "extended", "e", false, "include additional instance details")
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -23,5 +23,5 @@ var statusCmd = &cobra.Command{
 func init() {
 	root.Cmd().AddCommand(statusCmd)
 
-	statusCmd.Flags().BoolVarP(&statusCmdArgs.extended, "extended", "e", false, "include additional instance details")
+	statusCmd.Flags().BoolVarP(&statusCmdArgs.extended, "extended", "e", false, "include additional details")
 }


### PR DESCRIPTION
This PR adds the following details to `colima status` output:
- networkDriver
- cpu
- memory
- disk

Additional information is hidden behind the `--extended` flag.

Closes https://github.com/abiosoft/colima/issues/366.