### PR TITLE
Add disk adjustment instructions for qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Under vm-type qemu disk size can be adjusted using the `qemu-img` utility
 qemu-img resize ~/.lima/colima/diffdisk +10G
 ```
 
-Make sure to restart colima.
+Disk size will be resized on the VM next boot if it was created with lima 0.14+.
 
 **NOTE**: disk size cannot be changed with vm-type vz once the VM is created.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,15 @@ The VM can be customized either by passing additional flags to `colima start`.
 e.g. `--cpu`, `--memory`, `--disk`, `--runtime`.
 Or by editing the config file with `colima start --edit`.
 
-**NOTE**: disk size cannot be changed after the VM is created.
+Under vm-type qemu disk size can be adjusted using the `qemu-img` utility
+
+```
+qemu-img resize ~/.lima/colima/diffdisk +10G
+```
+
+Make sure to restart colima.
+
+**NOTE**: disk size cannot be changed with vm-type vz once the VM is created.
 
 #### Customization Examples
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Under vm-type qemu disk size can be adjusted using the `qemu-img` utility
 qemu-img resize ~/.lima/colima/diffdisk +10G
 ```
 
-Disk size will be resized on the VM next boot if it was created with lima 0.14+.
+Disk size changes will applied be on the VM next boot if it was created with lima 0.14+.
 
 **NOTE**: disk size cannot be changed with vm-type vz once the VM is created.
 


### PR DESCRIPTION
This PR adds instructions for disk adjustment for qemu. The changes made by `qemu-img` will be picked up by lima on next boot https://github.com/lima-vm/lima/blob/f26b412/pkg/cidata/cidata.TEMPLATE.d/boot/04-persistent-data-volume.sh#L16-L26.

Not sure aboute wording, feel free to modify it 😅 

Addresses issue mentioned in https://github.com/abiosoft/colima/issues/398.