### PR TITLE
[Meta] Update README with Ventura mount-type reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ Or by editing the config file with `colima start --edit`.
   colima start --arch aarch64 --vm-type=vz --vz-rosetta
   ```
 
+- set the mount-type to `9p` (defaults to `virtiofs` on MacOS Ventura)
+
+  ```
+  colima delete # reset
+  colima start --mount-type 9p
+  ```
+
+  If you are experiencing issues with volume mounting directories in MacOS Ventura (13.x) this may help, by resetting the mount type back to its default.
+
 ## Project Goal
 
 To provide container runtimes on macOS with minimal setup.


### PR DESCRIPTION
I was running into an issue with MacOS Ventura where by all directory volumes - where I link a directory on my host machine to one on the container - created with `docker-compose` are empty. I've tested the same scripts on MacOS 12.4 and 12.6 and they work as expected giving me the same directory contents on the container as on the host, so it seems v13 changed some permission. 

The `docker-compose.yml` file:

```
version: "3"

services:
  bash:
    image: ubuntu:latest
    stdin_open: true
    tty: true
    volumes:
      - ./:/app
    command: "/bin/bash"
```

So this should be creating a directory on the container called `/app` and linking that to the host directory the compose file is in.

But when I start the container:

```
❯ docker-compose up --build
[+] Running 1/0
 ⠿ Container ruby-docker-bash-1  Created  
Attaching to ruby-docker-bash-1
```

And login, the `/app` directory is empty:

```
❯ docker exec -it ruby-docker-bash-1 /bin/bash
root@9644de175d48:/# cd app/
root@9644de175d48:/app# ls -la
total 4
drwxr-xr-x 2 root root   40 Feb  1 09:59 .
drwxr-xr-x 1 root root 4096 Feb  1 09:39 ..
```

The `total 4` is really weird here as there are 4 files supposed to be there, but not accessible:

```
root@9644de175d48:/app# cat Gemfile
cat: Gemfile: No such file or directory
```

This is the directory contents on the host are:

```
❯ ls -la
.rw-r--r-- 2.7k paul  1 Feb 09:31 Dockerfile
.rw-r--r-- 3.9k paul  1 Feb 09:32 Gemfile
.rw-r--r--  27k paul  1 Feb 09:32 Gemfile.lock
.rw-r--r--  149 paul  1 Feb 10:00 docker-compose.yml
```

Then I found this: https://github.com/abiosoft/colima/issues/500#issuecomment-1343103477

```
colima delete # reset
colima start --mount-type 9p
```

I’ve been through the site, the readme, (there is no Wiki) and no where is the mount types documented, I guess it might be a Docker thing.

But [I did find this](https://github.com/abiosoft/colima/blob/51406badb45697da1d4cc2d0cb8225f7e2a3e55e/config/configmanager/config.go#L68-L70)…

```	
validMountTypes := map[string]bool{"9p": true, "sshfs": true}
if util.MacOS13OrNewer() {
	validMountTypes["virtiofs"] = true
}
```

I’m in MacOS 13, so it seems like there are issues with `virtiofs` and not in the older `9p` mount type, so i'd like to suggest adding a line to the README that might help others that run into this issue. 