### PR TITLE
vm: respect `$SHELL` in `colima ssh` when `layer=true`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -295,7 +295,7 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 	if len(args) > 0 {
 		args = append([]string{"-q", "-t", resp.IPAddress, "--"}, args...)
 	} else if workDir != "" {
-		args = []string{"-q", "-t", resp.IPAddress, "--", "cd " + workDir + " 2> /dev/null; bash --login"}
+		args = []string{"-q", "-t", resp.IPAddress, "--", "cd " + workDir + " 2> /dev/null; $SHELL --login"}
 	}
 
 	args = append(util.ShellSplit(cmdArgs), args...)

--- a/app/app.go
+++ b/app/app.go
@@ -295,7 +295,7 @@ func (c colimaApp) SSH(layer bool, args ...string) error {
 	if len(args) > 0 {
 		args = append([]string{"-q", "-t", resp.IPAddress, "--"}, args...)
 	} else if workDir != "" {
-		args = []string{"-q", "-t", resp.IPAddress, "--", "cd " + workDir + " 2> /dev/null; $SHELL --login"}
+		args = []string{"-q", "-t", resp.IPAddress, "--", "cd " + workDir + " 2> /dev/null; \"$SHELL\" --login"}
 	}
 
 	args = append(util.ShellSplit(cmdArgs), args...)


### PR DESCRIPTION
This PR replaces the hardcoded `bash` used when logging into the ubuntu layer with `$SHELL`.
This is useful in case the user sets their login shell to a different shell, e.g. zsh or fish.

It also goes in line with the way that lima handles ssh login itself:
https://github.com/lima-vm/lima/blob/6ae40d3a25a6ffa006bbc04d0e8433357e756e8a/cmd/limactl/shell.go#L124-L129