### PR TITLE
nix: update flake

### DIFF
--- a/colima.nix
+++ b/colima.nix
@@ -2,12 +2,12 @@
 
 with pkgs;
 
-buildGoModule {
+buildGo119Module {
   name = "colima";
   pname = "colima";
   src = ./.;
   nativeBuildInputs = [ installShellFiles makeWrapper git ];
-  vendorSha256 = "sha256-tsMQMWEkTE1NhevcqBETGWiboqL6QTepgnIo4B5Y4wQ=";
+  vendorSha256 = "sha256-bEgC7j8WvCgrJ2Ahye4mfWVEmo6Y/OO64mDIJXvtaiE=";
   CGO_ENABLED = 1;
 
   subPackages = [ "cmd/colima" ];

--- a/flake.lock
+++ b/flake.lock
@@ -16,16 +16,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656546896,
-        "narHash": "sha256-WpMqq6OHQinBZjxemh2jthIvUpNoqNwqpYipbZUOsQs=",
+        "lastModified": 1678654296,
+        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fb2acd492c96ea4a1a37ec060edb1e1774eeb5b",
+        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-22.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Container runtimes on macOS (and Linux) with minimal setup";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem
     (system:

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
 pkgs.mkShell {
   # nativeBuildInputs is usually what you want -- tools you need to run
   nativeBuildInputs = with pkgs.buildPackages; [
-    go_1_18
+    go_1_19
     git
     lima
     qemu


### PR DESCRIPTION
This PR switches nixpkgs flake input to unstable to solve https://github.com/abiosoft/colima/issues/556#issuecomment-1425134483, and switches to go 1.19 to make sure that flake builds properly.