### PR TITLE
k3s: use embedded cri-dockerd

### DIFF
--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -138,7 +138,7 @@ func installK3sCluster(
 
 	switch containerRuntime {
 	case docker.Name:
-		args = append(args, "--container-runtime-endpoint", "unix:///run/cri-dockerd.sock")
+		args = append(args, "--docker")
 	case containerd.Name:
 		args = append(args, "--container-runtime-endpoint", "unix:///run/containerd/containerd.sock")
 	}

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -129,12 +129,6 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 	{
 		// cni is used by both cri-dockerd and containerd
 		installCniConfig(c.guest, a)
-
-		if runtime == docker.Name {
-			a.Retry("waiting for docker cri", time.Second*2, 5, func(int) error {
-				return c.guest.Run("sudo", "service", "cri-dockerd", "start")
-			})
-		}
 	}
 
 	// provision successful, now we can persist the version


### PR DESCRIPTION
Attempting to start k3s 1.26.3 on colima with docker as container runtime results in a fatal kubelet error, preventing k3s from successfully starting.

```
time="2023-03-20T23:41:38Z" level=fatal msg="kubelet exited: failed to run Kubelet: validate service connection: CRI v1 runtime API is not implemented for endpoint \"unix:///run/cri-dockerd.sock\": rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService"
```

Not entirely sure whether this is the right thing to do, but [modern versions of k3s ship with an embedded version of cri-dockerd](https://github.com/k3s-io/k3s/blob/master/docs/adrs/cri-dockerd.md). Using this embedded version of cri-dockerd resolves the issue and k3s becomes usable after.
