### PR TITLE
Fix #483 - Use XDG Base Dir or platform dirs for config files

### DIFF
--- a/config/dirs.go
+++ b/config/dirs.go
@@ -42,12 +42,19 @@ func (r *requiredDir) Dir() string {
 var (
 	configBaseDir = requiredDir{
 		dir: func() (string, error) {
-			dir := os.Getenv("XDG_CONFIG_HOME")
+			dir, err := os.UserHomeDir()
+			dir = filepath.Join(dir, ".colima")
+			_, err = os.Stat(dir)
+			if err == nil {
+				return dir, nil
+			}
+			// else
+			dir = os.Getenv("XDG_CONFIG_HOME")
 			if dir != "" {
 				return filepath.Join(dir, "colima"), nil
 			}
 			// else
-			dir, err := os.UserConfigDir()
+			dir, err = os.UserConfigDir()
 			if err != nil {
 				return "", err
 			}

--- a/config/dirs.go
+++ b/config/dirs.go
@@ -61,7 +61,7 @@ var (
 			if err != nil {
 				return "", err
 			}
-			return filepath.Join(dir, ".colima", profile.ShortName), nil
+			return filepath.Join(dir, profile.ShortName), nil
 		},
 	}
 
@@ -86,7 +86,7 @@ var (
 			if err != nil {
 				return "", err
 			}
-			return filepath.Join(dir, "colima", "_templates"), nil
+			return filepath.Join(dir, "_templates"), nil
 		},
 	}
 
@@ -98,7 +98,7 @@ var (
 			}
 			// generate unique directory for the current binary
 			uniqueDir := shautil.SHA1(osutil.Executable())
-			return filepath.Join(dir, "colima", "_wrapper", uniqueDir.String()), nil
+			return filepath.Join(dir, "_wrapper", uniqueDir.String()), nil
 		},
 	}
 )

--- a/config/dirs.go
+++ b/config/dirs.go
@@ -40,9 +40,24 @@ func (r *requiredDir) Dir() string {
 }
 
 var (
+	configBaseDir = requiredDir{
+		dir: func() (string, error) {
+			dir := os.Getenv("XDG_CONFIG_HOME")
+			if dir != "" {
+				return filepath.Join(dir, "colima"), nil
+			}
+			// else
+			dir, err := os.UserConfigDir()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(dir, "colima"), nil
+		},
+	}
+
 	configDir = requiredDir{
 		dir: func() (string, error) {
-			dir, err := os.UserHomeDir()
+			dir, err := configBaseDir.dir()
 			if err != nil {
 				return "", err
 			}
@@ -52,6 +67,11 @@ var (
 
 	cacheDir = requiredDir{
 		dir: func() (string, error) {
+			dir := os.Getenv("XDG_CACHE_HOME")
+			if dir != "" {
+				return filepath.Join(dir, "colima"), nil
+			}
+			// else
 			dir, err := os.UserCacheDir()
 			if err != nil {
 				return "", err
@@ -62,23 +82,23 @@ var (
 
 	templatesDir = requiredDir{
 		dir: func() (string, error) {
-			dir, err := os.UserHomeDir()
+			dir, err := configBaseDir.dir()
 			if err != nil {
 				return "", err
 			}
-			return filepath.Join(dir, ".colima", "_templates"), nil
+			return filepath.Join(dir, "colima", "_templates"), nil
 		},
 	}
 
 	wrapperDir = requiredDir{
 		dir: func() (string, error) {
-			dir, err := os.UserHomeDir()
+			dir, err := configBaseDir.dir()
 			if err != nil {
 				return "", err
 			}
 			// generate unique directory for the current binary
 			uniqueDir := shautil.SHA1(osutil.Executable())
-			return filepath.Join(dir, ".colima", "_wrapper", uniqueDir.String()), nil
+			return filepath.Join(dir, "colima", "_wrapper", uniqueDir.String()), nil
 		},
 	}
 )


### PR DESCRIPTION
If the environment variable XDG_CONFIG_HOME is set, the Colima configuration should be (shell syntax) `"${XDG_CONFIG_HOME}/colima`.

Likewise, if XDG_CACHE_HOME is set, then the cache should be in `"${XDG_CACHE_HOME}/colima`.

If these variables are not set, use the Go standard lib `os.UserConfigDir()` for the configuration. _On macOS, that will be `$HOME/Library/Application Support/colima`; on Linux it defaults to `$HOME/.config/colima`_.

This patch addresses #483, and possibly helps #724.