### PR TITLE
nix: fix vendorSha256 in colima.nix

### DIFF
--- a/colima.nix
+++ b/colima.nix
@@ -7,7 +7,7 @@ buildGo119Module {
   pname = "colima";
   src = ./.;
   nativeBuildInputs = [ installShellFiles makeWrapper git ];
-  vendorSha256 = "sha256-bEgC7j8WvCgrJ2Ahye4mfWVEmo6Y/OO64mDIJXvtaiE=";
+  vendorSha256 = "sha256-lsTvzGFoC3Brnr1Q0Hl0ZqEDfcTeQ8vWGe+xylTyvts=";
   CGO_ENABLED = 1;
 
   subPackages = [ "cmd/colima" ];


### PR DESCRIPTION
While attempting to install colima via nix, I encountered the following error:

```
error: hash mismatch in fixed-output derivation '/nix/store/iz5w0f1hnjvh5w39q3gpiv10708188rl-colima-go-modules.drv':
         specified: sha256-bEgC7j8WvCgrJ2Ahye4mfWVEmo6Y/OO64mDIJXvtaiE=
            got:    sha256-lsTvzGFoC3Brnr1Q0Hl0ZqEDfcTeQ8vWGe+xylTyvts=
```

This change updates the hash to the correct hash indicated by the error output.