### PR TITLE
vm: temporary workaround for #764

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -197,6 +197,9 @@ func init() {
 	// dns
 	startCmd.Flags().IPSliceVarP(&startCmdArgs.Network.DNSResolvers, "dns", "n", nil, "DNS resolvers for the VM")
 	startCmd.Flags().StringSliceVar(&startCmdArgs.Flags.DNSHosts, "dns-host", nil, "custom DNS names to provide to resolver")
+
+	// cgroups v2 workaround
+	startCmd.Flags().BoolVar(&startCmdArgs.TempCgroupsV2, "cgroups-v2", false, "cgroups v2 workaround for docker-compose")
 }
 
 func dnsHostsFromFlag(hosts []string) map[string]string {
@@ -399,6 +402,10 @@ func prepareConfig(cmd *cobra.Command) {
 		if current.ActivateRuntime != nil { // backward compatibility for `activate`
 			startCmdArgs.ActivateRuntime = current.ActivateRuntime
 		}
+	}
+	// cgroups v2 temp workaround
+	if !cmd.Flag("cgroups-v2").Changed {
+		startCmdArgs.TempCgroupsV2 = current.TempCgroupsV2
 	}
 	if util.MacOS() {
 		if !cmd.Flag("network-driver").Changed {

--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,9 @@ type Config struct {
 
 	// SSH config generation
 	SSHConfig bool `yaml:"sshConfig,omitempty"`
+
+	// Temporary workaround for cgroups v2.
+	TempCgroupsV2 bool `yaml:"cgroupsV2,omitempty"`
 }
 
 // Kubernetes is kubernetes configuration

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -190,3 +190,8 @@ mounts: []
 #
 # Default: {}
 env: {}
+
+# Enable cgroups v2 as a temporary workaround for https://github.com/abiosoft/colima/issues/764.
+# NOTE: this is incompatible with Kubernetes and Ubuntu Layer.
+# NOTE: this config will be removed in future versions.
+cgroupsV2: false

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -119,6 +119,33 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 			Script: `grep -q "^rc_env_allow" /etc/rc.conf || echo 'rc_env_allow="*"' >> /etc/rc.conf`,
 		})
 
+		// cgroups v2 workaround
+		{
+			// delete setting if present
+			l.Provision = append(l.Provision, Provision{
+				Mode:   ProvisionModeSystem,
+				Script: `(grep -q "^rc_cgroup_mode" /etc/rc.conf && sed -i '/^rc_cgroup_mode/d' /etc/rc.conf && service cgroups restart) || echo 'cgroup v2 config not found'`,
+			})
+
+			// validate workaround is supported
+			if conf.TempCgroupsV2 {
+				if conf.Kubernetes.Enabled {
+					logrus.Warnln("cgroups v2 workaround not compatible with Kubernetes, ignoring...")
+					conf.TempCgroupsV2 = false
+				}
+				if conf.Layer {
+					logrus.Warnln("cgroups v2 workaround not compatible with Ubuntu layer, ignoring...")
+					conf.TempCgroupsV2 = false
+				}
+			}
+
+			if conf.TempCgroupsV2 {
+				l.Provision = append(l.Provision, Provision{
+					Mode:   ProvisionModeSystem,
+					Script: `echo 'rc_cgroup_mode="unified"' >> /etc/rc.conf && service cgroups restart`,
+				})
+			}
+		}
 	}
 
 	// network setup


### PR DESCRIPTION
This introduces a `--cgroups-v2` flag for `colima start` as a temporary stopgap for #764.
