### PR TITLE
chore: remove redundant `len` check

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -109,10 +109,8 @@ func (l processManager) Start(ctx context.Context, conf config.Config) error {
 	}
 	if conf.Network.Driver == gvproxy.Name {
 		args = append(args, "--gvproxy")
-		if len(conf.Network.DNSHosts) > 0 {
-			for host, ip := range conf.Network.DNSHosts {
-				args = append(args, "--gvproxy-hosts", host+"="+ip)
-			}
+		for host, ip := range conf.Network.DNSHosts {
+			args = append(args, "--gvproxy-hosts", host+"="+ip)
 		}
 	}
 


### PR DESCRIPTION
From the Go specification (https://go.dev/ref/spec#For_range):

> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the map is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` around a loop is unnecessary.