### PR TITLE
Allow dev version of lima

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -127,11 +127,7 @@ func LimaVersionSupported() error {
 	}
 
 	if parts[0] == "HEAD" {
-		version := parts[0]
-		if len(parts) > 1 {
-			version = parts[1]
-		}
-		logrus.Warnf("to avoid compatibility issues, ensure lima development version (%s) in use is not lower than %s", version, limaVersion)
+		logrus.Warnf("to avoid compatibility issues, ensure lima development version (%s) in use is not lower than %s", values.Version, limaVersion)
 		return nil
 	}
 

--- a/core/core.go
+++ b/core/core.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/abiosoft/colima/cli"
@@ -120,8 +121,18 @@ func LimaVersionSupported() error {
 		return fmt.Errorf("error decoding 'limactl info' json: %w", err)
 	}
 	// remove pre-release hyphen
-	if str := strings.SplitN(values.Version, "-", 2); len(str) > 0 {
-		values.Version = str[0]
+	parts := strings.SplitN(values.Version, "-", 2)
+	if len(parts) > 0 {
+		values.Version = parts[0]
+	}
+
+	if parts[0] == "HEAD" {
+		version := parts[0]
+		if len(parts) > 1 {
+			version = parts[1]
+		}
+		logrus.Warnf("to avoid compatibility issues, ensure lima development version (%s) in use is not lower than %s", version, limaVersion)
+		return nil
 	}
 
 	min := semver.New(strings.TrimPrefix(limaVersion, "v"))


### PR DESCRIPTION
The latest release of colima made it impossible to use a dev version of lima. This change allows the user to use a dev version but prints a warning.