### PR TITLE
vm: do not call mkmntdirs, it does not exists

### DIFF
--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -244,7 +244,7 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 
 	l.Provision = append(l.Provision, Provision{
 		Mode:   ProvisionModeSystem,
-		Script: "mkmntdirs && mount -a",
+		Script: "mount -a",
 	})
 
 	// trim mounted drive to recover disk space


### PR DESCRIPTION
Attempt to fix the following error at boot:

```
Nov 17 14:24:04 colima systemd-hostnamed[1859]: Hostname set to <colima> (static)
Nov 17 14:24:04 colima cloud-init[1697]: LIMA| Executing /mnt/lima-cidata/provision.system/00000003
Nov 17 14:24:04 colima cloud-init[1697]: /mnt/lima-cidata/provision.system/00000003: 1: mkmntdirs: not found
Nov 17 14:24:04 colima cloud-init[1697]: LIMA| WARNING: Failed to execute /mnt/lima-cidata/provision.system/00000003

...

Nov 17 14:24:04 colima cloud-init[1697]: Cloud-init v. 23.3.1-0ubuntu2 finished at Fri, 17 Nov 2023 14:24:04 +0000. Datasource DataSourceNoCloud [seed=/dev/vdb][dsmode=net].  Up 5.89 seconds
Nov 17 14:24:04 colima systemd[1]: cloud-final.service: Main process exited, code=exited, status=1/FAILURE
Nov 17 14:24:04 colima systemd[1]: cloud-final.service: Failed with result 'exit-code'.
Nov 17 14:24:04 colima systemd[1]: cloud-final.service: Unit process 1696 (sh) remains running after unit stopped.
Nov 17 14:24:04 colima systemd[1]: cloud-final.service: Unit process 1697 (tee) remains running after unit stopped.
Nov 17 14:24:04 colima systemd[1]: Failed to start cloud-final.service - Execute cloud user/final scripts.
```

