### PR TITLE
cli: add prune command

### DIFF
--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/abiosoft/colima/cli"
+	"github.com/abiosoft/colima/cmd/root"
+	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/environment/vm/lima/limautil"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var pruneCmdArgs struct {
+	force bool
+	all   bool
+}
+
+// pruneCmd represents the prune command
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "prune cached downloaded assets",
+	Long:  `Prune cached downloaded assets`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		colimaCacheDir := config.CacheDir()
+		limaCacheDir := filepath.Join(filepath.Dir(colimaCacheDir), "lima")
+		if !pruneCmdArgs.force {
+			msg := "'" + colimaCacheDir + "' will be emptied, are you sure"
+			if pruneCmdArgs.all {
+				msg = "'" + colimaCacheDir + "' and '" + limaCacheDir + "' will be emptied, are you sure"
+			}
+			if y := cli.Prompt(msg); !y {
+				return nil
+			}
+		}
+		logrus.Info("Pruning ", strconv.Quote(config.CacheDir()))
+		if err := os.RemoveAll(config.CacheDir()); err != nil {
+			return fmt.Errorf("error during prune: %w", err)
+		}
+
+		if pruneCmdArgs.all {
+			cmd := limautil.Limactl("prune")
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("error during Lima prune: %w", err)
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	root.Cmd().AddCommand(pruneCmd)
+
+	pruneCmd.Flags().BoolVarP(&pruneCmdArgs.force, "force", "f", false, "do not prompt for yes/no")
+	pruneCmd.Flags().BoolVarP(&pruneCmdArgs.all, "all", "a", false, "include Lima assets")
+}

--- a/environment/vm/lima/dependencies.go
+++ b/environment/vm/lima/dependencies.go
@@ -14,8 +14,8 @@ import (
 )
 
 var dependencyPackages = []string{
-	// docker
-	"docker.io",
+	// docker and k8s
+	"docker.io", "socat",
 	// utilities
 	"htop", "vim", "inetutils-ping", "dnsutils",
 }

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -45,7 +45,7 @@ func New(host environment.HostActions) environment.VM {
 const (
 	envLimaInstance = "LIMA_INSTANCE"
 	lima            = "lima"
-	limactl         = limautil.Limactl
+	limactl         = limautil.LimactlCommand
 )
 
 func (l limaVM) limaConfFile() string {

--- a/environment/vm/lima/limautil/limautil.go
+++ b/environment/vm/lima/limautil/limautil.go
@@ -18,11 +18,12 @@ import (
 // EnvLimaHome is the environment variable for the Lima directory.
 const EnvLimaHome = "LIMA_HOME"
 
-// Limactl is the limactl command.
-const Limactl = "limactl"
+// LimactlCommand is the limactl command.
+const LimactlCommand = "limactl"
 
-func limactl(args ...string) *exec.Cmd {
-	cmd := cli.Command(Limactl, args...)
+// Limactl prepares a limactl command.
+func Limactl(args ...string) *exec.Cmd {
+	cmd := cli.Command(LimactlCommand, args...)
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, EnvLimaHome+"="+LimaHome())
 	return cmd
@@ -98,7 +99,7 @@ const (
 func getInstance(profileID string) (InstanceInfo, error) {
 	var i InstanceInfo
 	var buf bytes.Buffer
-	cmd := limactl("list", profileID, "--json")
+	cmd := Limactl("list", profileID, "--json")
 	cmd.Stderr = nil
 	cmd.Stdout = &buf
 
@@ -125,7 +126,7 @@ func Instances(ids ...string) ([]InstanceInfo, error) {
 	args := append([]string{"list", "--json"}, limaIDs...)
 
 	var buf bytes.Buffer
-	cmd := limactl(args...)
+	cmd := Limactl(args...)
 	cmd.Stderr = nil
 	cmd.Stdout = &buf
 
@@ -171,7 +172,7 @@ func Instances(ids ...string) ([]InstanceInfo, error) {
 func getIPAddress(profileID, interfaceName string) string {
 	var buf bytes.Buffer
 	// TODO: this should be less hacky
-	cmd := limactl("shell", profileID, "sh", "-c",
+	cmd := Limactl("shell", profileID, "sh", "-c",
 		`ip -4 addr show `+interfaceName+` | grep inet | awk -F' ' '{print $2 }' | cut -d/ -f1`)
 	cmd.Stderr = nil
 	cmd.Stdout = &buf


### PR DESCRIPTION
This adds `prune` command to clear downloaded assets.

```
colima prune --help                                                                                                                            administrator@50029
Prune cached downloaded assets

Usage:
  colima prune [flags]

Flags:
  -a, --all     include Lima assets
  -f, --force   do not prompt for yes/no
  -h, --help    help for prune

Global Flags:
  -p, --profile string   profile name, for multiple instances (default "default")
  -v, --verbose          enable verbose log
      --very-verbose     enable more verbose log

```