### PR TITLE
vm: purge packages instead of just removing them

### DIFF
--- a/environment/vm/lima/deb/docker.go
+++ b/environment/vm/lima/deb/docker.go
@@ -25,7 +25,7 @@ type Docker struct {
 
 // PreInstall implements URISource.
 func (d *Docker) PreInstall() error {
-	return d.Guest.RunQuiet("sh", "-c", "sudo apt remove -y docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc")
+	return d.Guest.RunQuiet("sh", "-c", "sudo apt purge -y docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc")
 }
 
 // Install implements URISource.


### PR DESCRIPTION
Without purging, packages not fully removed (e.g. dpkg -l will still show the packages).