### PR TITLE
vm: do not require optional system utilities

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -123,12 +123,12 @@ jobs:
 
       - name: Delay
         run: sleep 10
-      
+
       - name: Validate Docker
         run: docker ps && docker info
 
       - name: Validate DNS
-        run: colima ssh -- nslookup host.docker.internal
+        run: colima ssh -- sh -c "sudo apt-get update -y -qq && sudo apt-get install -qq dnsutils && nslookup host.docker.internal"
 
       - name: Build Image
         run: docker build integration
@@ -173,7 +173,7 @@ jobs:
         run: colima nerdctl ps && colima nerdctl info
 
       - name: Validate DNS
-        run: colima ssh -- nslookup host.docker.internal
+        run: colima ssh -- sh -c "sudo apt-get update -y -qq && sudo apt-get install -qq dnsutils && nslookup host.docker.internal"
 
       - name: Build Image
         run: colima nerdctl -- build integration

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -139,7 +139,7 @@ cpuType: host
 # EXAMPLE - script executed as root
 # provision:
 #   - mode: system
-#     script: apk add htop vim
+#     script: apt-get install htop vim
 #
 # EXAMPLE - script executed as user
 # provision:

--- a/environment/vm/lima/deb/mantic.go
+++ b/environment/vm/lima/deb/mantic.go
@@ -12,8 +12,6 @@ var manticPackages = []string{
 	"iptables",
 	// k8s
 	"socat",
-	// utilities
-	"htop", "vim", "inetutils-ping", "dnsutils",
 }
 
 var _ URISource = (*Mantic)(nil)


### PR DESCRIPTION
"htop", "vim", "inetutils-ping", "dnsutils" are optional dependencies - only required for developers working on colima.

I'd like to get some feedback on possibly moving these packages out of the main codebase into the configuration file. This would enable developers removing these packages without patching colima core source code.

Thanks !

 