### PR TITLE
vm: remove virtiofs workaround

### DIFF
--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -254,15 +254,6 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 		Script: `readlink /usr/sbin/fstrim || fstrim -a`,
 	})
 
-	// workaround for slow virtiofs https://github.com/drud/ddev/issues/4466#issuecomment-1361261185
-	// TODO: remove when fixed upstream
-	if l.MountType == VIRTIOFS {
-		l.Provision = append(l.Provision, Provision{
-			Mode:   ProvisionModeSystem,
-			Script: `stat /sys/class/block/vda/queue/write_cache && echo 'write through' > /sys/class/block/vda/queue/write_cache`,
-		})
-	}
-
 	if len(conf.Mounts) == 0 {
 		l.Mounts = append(l.Mounts,
 			Mount{Location: "~", Writable: true},


### PR DESCRIPTION
See https://github.com/ddev/ddev/issues/4466 .

Is this workaround still needed in colima ? 