### PR TITLE
vm: do not install recommended packages

### DIFF
--- a/environment/vm/lima/deb/mantic.go
+++ b/environment/vm/lima/deb/mantic.go
@@ -44,7 +44,7 @@ func (m *Mantic) URIs(_ environment.Arch) ([]string, error) {
 
 	output := ""
 	for _, p := range manticPackages {
-		line := fmt.Sprintf(`sudo apt-get install --reinstall --print-uris -qq "%s" | cut -d"'" -f2`, p)
+		line := fmt.Sprintf(`sudo apt-get install --reinstall --no-install-recommends --print-uris -qq "%s" | cut -d"'" -f2`, p)
 		out, err := m.Guest.RunOutput("sh", "-c", line)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching dependencies list: %w", err)


### PR DESCRIPTION
See https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html#depends for the definition of Recommended packages.

Not installing Recommended packages makes the generation more controllable and predictable.

Currently, in practice as an example docker-ce will no longer install docker-ce-rootless-extras .