### PR TITLE
deps: add opt to skip caching dependencies

### DIFF
--- a/environment/vm/lima/dependencies.go
+++ b/environment/vm/lima/dependencies.go
@@ -79,6 +79,15 @@ func (l *limaVM) installDependencies(log *logrus.Entry, conf config.Config) erro
 			log.Warn(fmt.Errorf("preinstall check failed for %s: %w", src.Name(), err))
 		}
 
+		if os.Getenv("COLIMA_SKIP_CACHE_DEPS") != "" {
+			log.Info("skipping cache dependencies")
+			if err := src.Install(); err != nil {
+				return fmt.Errorf("error installing packages using %s: %w", src.Name(), err)
+			}
+			// installed
+			continue
+		}
+
 		// cache dependencies
 		dir, err := l.cacheDependencies(src, log, conf)
 		if err != nil {


### PR DESCRIPTION
When implementing #892, I haven't realized that cached dependencies take precedence over the standard installation which handles specifying version and channel for docker installation.

This PR adds an env var `COLIMA_SKIP_CACHE_DEPS` so it can do a direct install and skip caching dependencies. This also makes sense when used in CI environment like GitHub Actions where runners are ephemeral.

Let me know if an env var and its name makes sense.