### PR TITLE
k3s: Update default template version

### DIFF
--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -33,7 +33,7 @@ kubernetes:
   # Kubernetes version to use.
   # This needs to exactly match a k3s version https://github.com/k3s-io/k3s/releases
   # Default: latest stable release
-  version: v1.24.3+k3s1
+  version: v1.28.3+k3s2
 
   # Additional args to pass to k3s https://docs.k3s.io/cli/server
   # Default: traefik is disabled


### PR DESCRIPTION
Bumping k3s template version to avoid confusion as in https://github.com/abiosoft/colima/discussions/945