### PR TITLE
core: update disk images

### DIFF
--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -51,13 +51,13 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 	l.Images = append(l.Images,
 		File{
 			Arch:     environment.AARCH64,
-			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8-1/ubuntu-23.10-minimal-cloudimg-arm64.qcow2",
-			Digest:   "sha512:038bf171a114d15246e18dfd4986f22c2670f1128c4fe3e29b221a34a157557f3285612bc1e4e3550465d0c3516543938f8c3f2ca1057c4276d17a95fc6b682b",
+			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8-2/ubuntu-23.10-minimal-cloudimg-arm64.qcow2",
+			Digest:   "sha512:00e3339bdebd98c3e003570ffb3ad4b01630fe4fcecd15061d5d58e14c07b211c718ed20fa3e4cce227d3b1c59fd98241eaa3e9e2cdfa04acfe32b4bc385428c",
 		},
 		File{
 			Arch:     environment.X8664,
-			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8-1/ubuntu-23.10-minimal-cloudimg-amd64.qcow2",
-			Digest:   "sha512:774ec7f20c8d7faf113446bd6081dd7e49b5b8334288038798992d20605c0f0428d766adfc706fc4af864ebb4ab6b774fdb8e499e36f28e5cc0134b6a3cfe3f7",
+			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8-2/ubuntu-23.10-minimal-cloudimg-amd64.qcow2",
+			Digest:   "sha512:97a6df4d4f4d13267fc7989933da537071513b3175a5785728992a8a198e0ceaaa0eaa2a9a4b01beaf6b998cc20b5995dc701e5c6d9ba2f4308e4208a84215df",
 		},
 	)
 

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -101,11 +101,11 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 		// "sudo", "usermod", "-aG", "docker", user
 		l.Provision = append(l.Provision, Provision{
 			Mode:   ProvisionModeDependency,
-			Script: "groupadd -f docker && usermod -aG docker $LIMA_CIDATA_USER",
+			Script: "groupadd -f docker && usermod -aG docker {{ .User }}",
 		})
 
 		// set hostname
-		hostname := "$LIMA_CIDATA_NAME"
+		hostname := config.CurrentProfile().ID
 		if conf.Hostname != "" {
 			hostname = conf.Hostname
 		}

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -51,13 +51,13 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 	l.Images = append(l.Images,
 		File{
 			Arch:     environment.AARCH64,
-			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.7/ubuntu-23.10-minimal-cloudimg-arm64.qcow2",
-			Digest:   "sha512:bbfd97c7aa9dc0f240cbe09f75f98eb19812ce5da1536e4bca2044c0528fd409b3c8f2c3ba85e54707544e3c6619d585504b3eca7ba8b3f3fbaba141cec0181c",
+			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8/ubuntu-23.10-minimal-cloudimg-arm64.qcow2",
+			Digest:   "sha512:da5a362c8ab2cb314395415b418808c96484fed0258dfe1794b33beb8cf72937afa6a8c1ac686c0ca0b86fe88b407a096ffee820b287c4b10b2580ab1d6ebb00",
 		},
 		File{
 			Arch:     environment.X8664,
-			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.7/ubuntu-23.10-minimal-cloudimg-amd64.qcow2",
-			Digest:   "sha512:9980ac00edc0a0b75e9c924f25f3403e76ef8fd680ee1847082de543a8ff851413992a18b065c53092edf298d11de50b0b129ece1ec17217bd8a6e9266b22345",
+			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8/ubuntu-23.10-minimal-cloudimg-amd64.qcow2",
+			Digest:   "sha512:3de11bb0ca7920bf08635dcd6ba447597ad2c36f4f5eb2f2d14d6bbf6f8a42b14b53173d9f7ec194713e81b1889908206eb9f2955389096310c4234f729d784d",
 		},
 	)
 

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -51,13 +51,13 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 	l.Images = append(l.Images,
 		File{
 			Arch:     environment.AARCH64,
-			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8/ubuntu-23.10-minimal-cloudimg-arm64.qcow2",
-			Digest:   "sha512:da5a362c8ab2cb314395415b418808c96484fed0258dfe1794b33beb8cf72937afa6a8c1ac686c0ca0b86fe88b407a096ffee820b287c4b10b2580ab1d6ebb00",
+			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8-1/ubuntu-23.10-minimal-cloudimg-arm64.qcow2",
+			Digest:   "sha512:038bf171a114d15246e18dfd4986f22c2670f1128c4fe3e29b221a34a157557f3285612bc1e4e3550465d0c3516543938f8c3f2ca1057c4276d17a95fc6b682b",
 		},
 		File{
 			Arch:     environment.X8664,
-			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8/ubuntu-23.10-minimal-cloudimg-amd64.qcow2",
-			Digest:   "sha512:3de11bb0ca7920bf08635dcd6ba447597ad2c36f4f5eb2f2d14d6bbf6f8a42b14b53173d9f7ec194713e81b1889908206eb9f2955389096310c4234f729d784d",
+			Location: "https://github.com/abiosoft/colima-core/releases/download/v0.6.8-1/ubuntu-23.10-minimal-cloudimg-amd64.qcow2",
+			Digest:   "sha512:774ec7f20c8d7faf113446bd6081dd7e49b5b8334288038798992d20605c0f0428d766adfc706fc4af864ebb4ab6b774fdb8e499e36f28e5cc0134b6a3cfe3f7",
 		},
 	)
 


### PR DESCRIPTION
Security update to fix the following CVEs.
- [CVE-2024-21626](https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv)
- [CVE-2024-23650](https://github.com/moby/buildkit/security/advisories/GHSA-9p26-698r-w4hx)
- [CVE-2024-23651](https://github.com/moby/buildkit/security/advisories/GHSA-m3r6-h7wv-7xxv)
- [CVE-2024-23652](https://github.com/moby/buildkit/security/advisories/GHSA-4v98-7qmw-rqr8)
- [CVE-2024-23653](https://github.com/moby/buildkit/security/advisories/GHSA-wr6v-9f75-vh2g)
- [CVE-2024-24557](https://github.com/moby/moby/security/advisories/GHSA-xw73-rw38-6vjc)