### PR TITLE
k3s: write kubeconfig to KUBECONFIG defined file

### DIFF
--- a/environment/container/kubernetes/kubeconfig.go
+++ b/environment/container/kubernetes/kubeconfig.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"

--- a/environment/container/kubernetes/kubeconfig.go
+++ b/environment/container/kubernetes/kubeconfig.go
@@ -42,6 +42,10 @@ func (c kubernetesRuntime) provisionKubeconfig(ctx context.Context) error {
 	})
 
 	kubeconfFile := filepath.Join(hostKubeDir, "config")
+	envKubeConfFile := c.host.Env("KUBECONFIG")
+	if envKubeConfFile != "" {
+		kubeconfFile = strings.Split(envKubeConfFile, ":")[0]
+	}
 	tmpkubeconfFile := filepath.Join(hostKubeDir, "."+profile, "colima-temp")
 
 	// manipulate in VM and save to host

--- a/environment/container/kubernetes/kubeconfig.go
+++ b/environment/container/kubernetes/kubeconfig.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -44,7 +45,7 @@ func (c kubernetesRuntime) provisionKubeconfig(ctx context.Context) error {
 	kubeconfFile := filepath.Join(hostKubeDir, "config")
 	envKubeConfFile := c.host.Env("KUBECONFIG")
 	if envKubeConfFile != "" {
-		kubeconfFile = strings.Split(envKubeConfFile, ":")[0]
+		kubeconfFile = strings.Split(envKubeConfFile, string(os.PathListSeparator))[0]
 	}
 	tmpkubeconfFile := filepath.Join(hostKubeDir, "."+profile, "colima-temp")
 

--- a/environment/container/kubernetes/kubeconfig.go
+++ b/environment/container/kubernetes/kubeconfig.go
@@ -45,7 +45,7 @@ func (c kubernetesRuntime) provisionKubeconfig(ctx context.Context) error {
 	kubeconfFile := filepath.Join(hostKubeDir, "config")
 	envKubeConfFile := c.host.Env("KUBECONFIG")
 	if envKubeConfFile != "" {
-		kubeconfFile = strings.Split(envKubeConfFile, string(os.PathListSeparator))[0]
+		filepath.SplitList(envKubeConfFile)[0]
 	}
 	tmpkubeconfFile := filepath.Join(hostKubeDir, "."+profile, "colima-temp")
 

--- a/environment/container/kubernetes/kubeconfig.go
+++ b/environment/container/kubernetes/kubeconfig.go
@@ -44,7 +44,7 @@ func (c kubernetesRuntime) provisionKubeconfig(ctx context.Context) error {
 	kubeconfFile := filepath.Join(hostKubeDir, "config")
 	envKubeConfFile := c.host.Env("KUBECONFIG")
 	if envKubeConfFile != "" {
-		filepath.SplitList(envKubeConfFile)[0]
+		kubeconfFile = filepath.SplitList(envKubeConfFile)[0]
 	}
 	tmpkubeconfFile := filepath.Join(hostKubeDir, "."+profile, "colima-temp")
 


### PR DESCRIPTION
Currently when starting a vm + k8s cluster the kubeconfig is always written to "~/.kube/config" which is the default path. By defining the env variable "KUBECONFIG" it is possible to override the default path. This does currently not apply to colima.
As it is possible to configure multiple locations with "KUBECONFIG" I opted to always use the first configured one as the location to save the config.