### PR TITLE
docker: Increase ulimit to infinity

### DIFF
--- a/environment/container/docker/daemon.go
+++ b/environment/container/docker/daemon.go
@@ -80,6 +80,7 @@ func (d dockerRuntime) addHostGateway(conf map[string]any) error {
 const systemdUnitFilename = "/etc/systemd/system/docker.service.d/docker.conf"
 const systemdUnitFileContent string = `
 [Service]
+LimitNOFILE=infinity
 ExecStart=
 ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock --host-gateway-ip=%s
 `


### PR DESCRIPTION
The current Colima VM (Ubuntu) is using the default value of 1024 file descriptors. This is insufficient for software such as Kafka that requires a high amount of open files, even in development environments.

https://docs.confluent.io/platform/current/kafka/deployment.html#file-descriptors-and-mmap

Since the principal purpose of the Colima VM is just to run docker, this sets the value to infinity to limit to the OS limits.