### PR TITLE
containerd: add socket forwarding to host

### DIFF
--- a/environment/container/containerd/containerd.go
+++ b/environment/container/containerd/containerd.go
@@ -3,14 +3,18 @@ package containerd
 import (
 	"context"
 	_ "embed"
+	"path/filepath"
 	"time"
 
 	"github.com/abiosoft/colima/cli"
+	"github.com/abiosoft/colima/config"
 	"github.com/abiosoft/colima/environment"
 )
 
 // Name is container runtime name
 const Name = "containerd"
+
+func HostSocketFile() string { return filepath.Join(config.Dir(), "containerd.sock") }
 
 // This is written with assumption that Lima is the VM,
 // which provides nerdctl/containerd support out of the box.

--- a/environment/container/containerd/containerd.go
+++ b/environment/container/containerd/containerd.go
@@ -14,6 +14,7 @@ import (
 // Name is container runtime name
 const Name = "containerd"
 
+// HostSocketFile returns the path to the containerd socket on host.
 func HostSocketFile() string { return filepath.Join(config.Dir(), "containerd.sock") }
 
 // This is written with assumption that Lima is the VM,

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/abiosoft/colima/config"
 	"github.com/abiosoft/colima/environment"
+	"github.com/abiosoft/colima/environment/container/containerd"
 	"github.com/abiosoft/colima/environment/container/docker"
 	"github.com/abiosoft/colima/util"
 	"github.com/sirupsen/logrus"
@@ -196,6 +197,16 @@ func newConf(ctx context.Context, conf config.Config) (l Config, err error) {
 						Proto:       TCP,
 					})
 			}
+		}
+
+		// containerd socket
+		if conf.Runtime == containerd.Name {
+			l.PortForwards = append(l.PortForwards,
+				PortForward{
+					GuestSocket: "/var/run/containerd.sock",
+					HostSocket:  containerd.HostSocketFile(),
+					Proto:       TCP,
+				})
 		}
 
 		// handle port forwarding to allow listening on 0.0.0.0


### PR DESCRIPTION
Small patch to expose the `containerd` socket to the host in similar fashion to how the Docker socket gets exposed.