### PR TITLE
core: ensure that the user defined `VMType` flag is respected for m3 devices

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -241,13 +241,13 @@ func mountsFromFlag(mounts []string) []config.Mount {
 func setDefaults(cmd *cobra.Command) {
 	if startCmdArgs.VMType == "" {
 		startCmdArgs.VMType = defaultVMType
-	}
 
-	// m3 devices cannot use qemu
-	if util.M3() {
-		startCmdArgs.VMType = "vz"
-		cmd.Flag("vm-type").Changed = true
-	}
+		// m3 devices cannot use qemu
+		if util.M3() {
+			startCmdArgs.VMType = "vz"
+			cmd.Flag("vm-type").Changed = true
+		}
+	} 
 
 	if util.MacOS13OrNewer() {
 		// changing to vz implies changing mount type to virtiofs


### PR DESCRIPTION
Hello! I'm creating this to ensure that the `--vm-type` flag is being respected. I understand that at one point qemu had issues on M3 chips, however in my current company we're experiencing issues using `vz`. As such, we've had to revert back to `qemu`, and it's worked a treat.

To get it going currently we need to run `coilima start --edit`, which is fine for testing, but being able to run start with qemu defined as the vm type **and** have that setting respected would be a game changer. Happy to work on this and improve if needed, but I think this should do the trick.