### PR TITLE
docs: update faq regarding docker bind mount issue

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -41,6 +41,7 @@
     - [Colima cannot access the internet.](#colima-cannot-access-the-internet)
     - [Docker Compose and Buildx showing runc error](#docker-compose-and-buildx-showing-runc-error)
       - [Version v0.5.6 or lower](#version-v056-or-lower)
+    - [Issue with Docker bind mount showing empty](#issue-with-docker-bind-mount-showing-empty)
 
 ## How does Colima compare to Lima?
 
@@ -380,3 +381,9 @@ runc run failed: unable to start container process: error during container init:
 From v0.5.6, start Colima with `--cgroups-v2` flag as a workaround.
 
 **This is fixed in v0.6.0.**
+
+### Issue with Docker bind mount showing empty
+
+When using docker to bind mount a volume (e.g. using `-v` or `--mount`) from the host where the volume is not contained within `/tmp/colima` or `/Users/$USER`, the container will start without raising any errors but the mapped mountpoint on the container will be empty.
+
+This is rectified by mounting the volume on the VM, and only then can docker map the volume or any subdirectory. Edit `$HOME/.colima/default/colima.yaml` and add to the `mounts` section (examples are provided within the yaml file), and then run `colima restart`. Start the container again with the desired bind mount and it should show up correctly.


### PR DESCRIPTION
Although most people won't run into the issue as they're probably mapping volumes from their `/Users/<username>` directory, I think this information would be handy for anyone running into the issue of docker bind mounts showing up empty on the container. This was the issue I faced in https://github.com/abiosoft/colima/issues/1051 and it took me 1-2 days to solve it.