### PR TITLE
core: revert to using qemu by default on M3 macs

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -241,12 +241,6 @@ func mountsFromFlag(mounts []string) []config.Mount {
 func setDefaults(cmd *cobra.Command) {
 	if startCmdArgs.VMType == "" {
 		startCmdArgs.VMType = defaultVMType
-
-		// m3 devices cannot use qemu
-		if util.M3() {
-			startCmdArgs.VMType = "vz"
-			cmd.Flag("vm-type").Changed = true
-		}
 	} 
 
 	if util.MacOS13OrNewer() {
@@ -280,10 +274,6 @@ func setConfigDefaults(conf *config.Config) {
 	// handle macOS virtualization.framework transition
 	if conf.VMType == "" {
 		conf.VMType = defaultVMType
-	}
-	// m3 devices cannot use qemu
-	if util.M3() {
-		conf.VMType = "vz"
 	}
 
 	if conf.MountType == "" {


### PR DESCRIPTION
This removes the special case logic for M3 macs that use the vz driver instead of qemu. A lot of people are having trouble with vz on M3 macs:

- https://github.com/abiosoft/colima/issues/987#issuecomment-1999938930
- https://github.com/abiosoft/colima/pull/1045#issue-2363549238
- https://github.com/abiosoft/colima/issues/985#issue-2132482350
- https://github.com/abiosoft/colima/issues/985#issuecomment-2024729107
- https://github.com/abiosoft/colima/issues/985#issuecomment-1987058790