### PR TITLE
core: add support for COLIMA_HOME env var

### DIFF
--- a/config/dirs.go
+++ b/config/dirs.go
@@ -42,8 +42,7 @@ var (
 	configBaseDir = requiredDir{
 		dir: func() (string, error) {
 			dir := os.Getenv("COLIMA_HOME")
-			_, err := os.Stat(dir)
-			if err == nil {
+			if _, err := os.Stat(dir); err == nil {
 				return dir, nil
 			}
 

--- a/config/dirs.go
+++ b/config/dirs.go
@@ -41,7 +41,13 @@ func (r *requiredDir) Dir() string {
 var (
 	configBaseDir = requiredDir{
 		dir: func() (string, error) {
-			dir, err := os.UserHomeDir()
+			dir := os.Getenv("COLIMA_HOME")
+			_, err := os.Stat(dir)
+			if err == nil {
+				return dir, nil
+			}
+
+			dir, err = os.UserHomeDir()
 			if err != nil {
 				return "", err
 			}

--- a/config/dirs.go
+++ b/config/dirs.go
@@ -46,7 +46,7 @@ var (
 				return dir, nil
 			}
 
-			dir, err = os.UserHomeDir()
+			dir, err := os.UserHomeDir()
 			if err != nil {
 				return "", err
 			}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -68,15 +68,19 @@ brew services start colima
 
 Yes, from v0.4.0, Colima support YAML configuration file.
 
+### Specifying the config location
+
+Set the `$COLIMA_HOME` environment variable, otherwise it defaults to `$HOME/.colima`.
+
 ### Editing the config
 
 ```
 colima start --edit
 ```
 
-For manual edit, the config file is located at `$HOME/.colima/default/colima.yaml`.
+For manual edit, the config file is located at `$COLIMA_HOME/default/colima.yaml`.
 
-For other profiles, `$HOME/.colima/<profile-name>/colima.yaml`
+For other profiles, `$COLIMA_HOME/<profile-name>/colima.yaml`
 
 ### Setting the default config
 
@@ -84,7 +88,7 @@ For other profiles, `$HOME/.colima/<profile-name>/colima.yaml`
 colima template
 ```
 
-For manual edit, the template file is located at `$HOME/.colima/_templates/default.yaml`.
+For manual edit, the template file is located at `$COLIMA_HOME/_templates/default.yaml`.
 
 ### Specifying the config editor
 
@@ -107,11 +111,11 @@ Colima makes itself the default Docker context on startup and should work straig
 
 #### v0.3.4 or older
 
-Docker socket is located at `$HOME/.colima/docker.sock`
+Docker socket is located at `$COLIMA_HOME/docker.sock`
 
 #### v0.4.0 or newer
 
-Docker socket is located at `$HOME/.colima/default/docker.sock`
+Docker socket is located at `$COLIMA_HOME/default/docker.sock`
 
 It can also be retrieved by checking status
 
@@ -143,12 +147,12 @@ This can be fixed by any of the following approaches. Ensure the Docker socket p
 2. Setting the `DOCKER_HOST` environment variable to point to Colima socket.
 
    ```sh
-   export DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock"
+   export DOCKER_HOST="unix://${COLIMA_HOME}/default/docker.sock"
    ```
 3. Linking the Colima socket to the default socket path. **Note** that this may break other Docker servers.
 
    ```sh
-   sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+   sudo ln -sf $COLIMA_HOME/default/docker.sock /var/run/docker.sock
    ```
 
 
@@ -156,7 +160,7 @@ This can be fixed by any of the following approaches. Ensure the Docker socket p
 
 * v0.3.4 or lower
 
-  On first startup, Colima generates Docker daemon.json file at `$HOME/.colima/docker/daemon.json`.
+  On first startup, Colima generates Docker daemon.json file at `$COLIMA_HOME/docker/daemon.json`.
   Modify the daemon.json file accordingly and restart Colima.
 
 * v0.4.0 or newer
@@ -399,4 +403,4 @@ From v0.5.6, start Colima with `--cgroups-v2` flag as a workaround.
 
 When using docker to bind mount a volume (e.g. using `-v` or `--mount`) from the host where the volume is not contained within `/tmp/colima` or `/Users/$USER`, the container will start without raising any errors but the mapped mountpoint on the container will be empty.
 
-This is rectified by mounting the volume on the VM, and only then can docker map the volume or any subdirectory. Edit `$HOME/.colima/default/colima.yaml` and add to the `mounts` section (examples are provided within the yaml file), and then run `colima restart`. Start the container again with the desired bind mount and it should show up correctly.
+This is rectified by mounting the volume on the VM, and only then can docker map the volume or any subdirectory. Edit `$COLIMA_HOME/default/colima.yaml` and add to the `mounts` section (examples are provided within the yaml file), and then run `colima restart`. Start the container again with the desired bind mount and it should show up correctly.

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -153,7 +153,7 @@ cpuType: host
 provision: []
 
 # Modify ~/.ssh/config automatically to include a SSH config for the virtual machine.
-# SSH config will still be generated in ~/.colima/ssh_config regardless.
+# SSH config will still be generated in $COLIMA_HOME/ssh_config regardless.
 # Default: true
 sshConfig: true
 


### PR DESCRIPTION
currently, colima configs get autopopulated in `$HOME/.colima`, this addition would allow users to set a `$COLIMA_HOME` environment variable to change this location if users have other preferences (i personally prefer all my program configs go in `$HOME/.config/{app_name}`)

I didn't see any information on contributing to this repo, but did see the hefty issue backlog i wouldn't want to make even bigger, so i thought it'd be ok to make a small PR myself! no worries if people see this change as unnecessary and decide to close it out tho