### PR TITLE
fix(docker): apply configuration on first boot

### DIFF
--- a/environment/container/docker/daemon.go
+++ b/environment/container/docker/daemon.go
@@ -77,6 +77,16 @@ func (d dockerRuntime) addHostGateway(conf map[string]any) error {
 	return nil
 }
 
+func (d dockerRuntime) reloadAndRestartSystemdService() error {
+	if err := d.guest.Run("sudo", "systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("error reloading systemd daemon: %w", err)
+	}
+	if err := d.guest.Run("sudo", "systemctl", "restart", "docker"); err != nil {
+		return fmt.Errorf("error restarting docker: %w", err)
+	}
+	return nil
+}
+
 const systemdUnitFilename = "/etc/systemd/system/docker.service.d/docker.conf"
 const systemdUnitFileContent string = `
 [Service]

--- a/environment/container/docker/docker.go
+++ b/environment/container/docker/docker.go
@@ -52,6 +52,9 @@ func (d dockerRuntime) Provision(ctx context.Context) error {
 		if err := d.addHostGateway(conf.Docker); err != nil {
 			log.Warnln(err)
 		}
+		if err := d.reloadAndRestartSystemdService(); err != nil {
+			log.Warnln(err)
+		}
 		return nil
 	})
 


### PR DESCRIPTION
The initialization sequence is:
 (1) VM boot
 (2) Write daemon configuration

When the VM boot, the Docker systemd service is started, so the new configuration is not picked up until the next VM boot.

To fix this, reload the systemd daemon config (to pick up the systemd service file written by `addHostGateway`) and then restart the Docker systemd service, which will use the new systemd unit file as well as any customizations to `daemon.json`.

### Related Issues
* #834
* #1060

(My specific issue was that my `daemon.json` customizations in the `docker` section of `colima.yaml` were not being applied on first boot.)