### PR TITLE
core: fix downloader duplicating downloads

### DIFF
--- a/util/downloader/download.go
+++ b/util/downloader/download.go
@@ -132,7 +132,7 @@ func (d downloader) downloadFile(r Request) (err error) {
 	}
 
 	// get rid of curl's initial progress bar by getting the redirect url directly.
-	downloadURL, err := d.host.RunOutput("curl", "-Ls", "-o", "/dev/null", "-w", "%{url_effective}", r.URL)
+	downloadURL, err := d.host.RunOutput("curl", "-ILs", "-o", "/dev/null", "-w", "%{url_effective}", r.URL)
 	if err != nil {
 		return fmt.Errorf("error retrieving redirect url: %w", err)
 	}


### PR DESCRIPTION
Fixes #1098.

The downloader currently has undesired behaviour of downloading twice when fetching the possible redirect URL of the asset to be downloaded.

This resolves it by ensuring the initial request is an HEAD request.