### PR TITLE
chore: generate checksum files after signing assets by codesign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ fmt:
 .PHONY: build
 build:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags="$(LDFLAGS)" -o $(OUTPUT_DIR)/$(OUTPUT_BIN) ./cmd/colima
+	codesign -s - $(OUTPUT_DIR)/$(OUTPUT_BIN)
 	cd $(OUTPUT_DIR) && openssl sha256 -r -out $(OUTPUT_BIN).sha256sum $(OUTPUT_BIN)
 ifeq ($(GOOS),darwin)
-	codesign -s - $(OUTPUT_DIR)/$(OUTPUT_BIN)
 endif
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ fmt:
 .PHONY: build
 build:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags="$(LDFLAGS)" -o $(OUTPUT_DIR)/$(OUTPUT_BIN) ./cmd/colima
-	codesign -s - $(OUTPUT_DIR)/$(OUTPUT_BIN)
-	cd $(OUTPUT_DIR) && openssl sha256 -r -out $(OUTPUT_BIN).sha256sum $(OUTPUT_BIN)
 ifeq ($(GOOS),darwin)
+	codesign -s - $(OUTPUT_DIR)/$(OUTPUT_BIN)
 endif
+	cd $(OUTPUT_DIR) && openssl sha256 -r -out $(OUTPUT_BIN).sha256sum $(OUTPUT_BIN)
 
 .PHONY: test
 test:


### PR DESCRIPTION
- https://github.com/abiosoft/colima/issues/1106

This pull request fixes checksums of assets for macOS.

From colima v0.7.1, assets for macOS are signed by codesign.

- https://github.com/abiosoft/colima/commit/3415501d7d1977390c844f16639d2011817ad468
- https://github.com/abiosoft/colima/pull/1094

But due to this checksums became invalid.

```console
$ gh release download abiosoft/colima v0.7.1

$ cat *.sha256sum
9db4f5617eb3a16ef4abca4d515a7e81b80f7f8646a8c3fe50e4eb6e6e1a8ccb *colima-Darwin-arm64
e136336f3b000fda729f4266d1af573dcf3378568d4c5433c6b63350f960f296 *colima-Darwin-x86_64
f866550da41a4d1df7437fbf2e42449e213281ac1784d2f4d905e7bd13c5c772 *colima-Linux-aarch64
95cdef8ffc9fa2620a9a4c0771c4eab727b5d654341a0b6fcc70842c2bc38486 *colima-Linux-x86_64

$ sha256sum colima-Darwin-arm64 colima-Darwin-x86_64 colima-Linux-aarch64 colima-Linux-x86_64
df99434b42f0f85da5fa86063f86d7e818a19fcb46da528fe4201d9f6356744e  colima-Darwin-arm64
abdf3069c8e6d35b1b23730cb320729eb53800b1049a4973f550e1ee4f62fa99  colima-Darwin-x86_64
f866550da41a4d1df7437fbf2e42449e213281ac1784d2f4d905e7bd13c5c772  colima-Linux-aarch64
95cdef8ffc9fa2620a9a4c0771c4eab727b5d654341a0b6fcc70842c2bc38486  colima-Linux-x86_64
```

codesign changed assets, so we need to generate checksum files after running codesign.
