### PR TITLE
cli: fix broken flag for non-m3 devices on macOS 15

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -171,7 +171,7 @@ func init() {
 		}
 
 		// nested virtualization
-		if util.M3() && util.MacOS15OrNewer() {
+		if util.MacOSNestedVirtualizationSupported() {
 			startCmd.Flags().BoolVarP(&startCmdArgs.NestedVirtualization, "nested-virtualization", "z", false, "enable nested virtualization")
 			startCmd.Flag("nested-virtualization").Hidden = true
 		}
@@ -457,7 +457,7 @@ func prepareConfig(cmd *cobra.Command) {
 				startCmdArgs.VZRosetta = current.VZRosetta
 			}
 		}
-		if util.MacOS15OrNewer() {
+		if util.MacOSNestedVirtualizationSupported() {
 			if !cmd.Flag("nested-virtualization").Changed {
 				startCmdArgs.NestedVirtualization = current.NestedVirtualization
 			}

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -44,7 +44,7 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 			}
 		}
 
-		if util.MacOS15OrNewer() {
+		if util.MacOSNestedVirtualizationSupported() {
 			l.NestedVirtualization = conf.NestedVirtualization
 		}
 	}

--- a/util/macos.go
+++ b/util/macos.go
@@ -29,6 +29,11 @@ func MacOS13OrNewer() bool { return minMacOSVersion("13.0.0") }
 // MacOS15OrNewer returns if the current OS is macOS 15 or newer.
 func MacOS15OrNewer() bool { return minMacOSVersion("15.0.0") }
 
+// MacOSNestedVirtualizationSupported returns if the current device supports nested virtualization.
+func MacOSNestedVirtualizationSupported() bool {
+	return M3() && MacOS15OrNewer()
+}
+
 func minMacOSVersion(version string) bool {
 	if !MacOS() {
 		return false


### PR DESCRIPTION
Fixes #1109 