### PR TITLE
docker: remove cert cache directory before copying host certs

### DIFF
--- a/environment/vm/lima/certs.go
+++ b/environment/vm/lima/certs.go
@@ -23,6 +23,9 @@ func (l limaVM) copyCerts() error {
 
 		// copy to cache dir
 		dockerCertsCacheDir := filepath.Join(config.CacheDir(), "docker-certs")
+		if err := l.host.RunQuiet("rm", "-r", dockerCertsCacheDir); err != nil {
+			return err
+		}
 		if err := l.host.RunQuiet("mkdir", "-p", dockerCertsCacheDir); err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, colima would copy self-signed root CA certs from the `~/.docker.certs.d/` directory to the VM. This allows docker daemon in the VM to pull from registries that are signed with a self-signed cert. 

However, when removing certs from the `~/.docker/certs.d` directory, they would not be removed from the VM. More confusingly, even after running `colima delete && colima start`, the same custom certs are still present in the newly created VM. 

This PR would first delete the intermediate cache directory prior to copying the certs from `~/.docker/certs.d`, which should resolve the certs persistence across colima deletion/creation. 

Note that certs will still be persisted across colima restart, since they are still present in the VM. While we can simply remove all certs from `/etc/docker/certs.d`, it would be trickier to selectively remove the added certs in `/etc/ssl/certs`, and we can probably tackle that in a subsequent PR.