### PR TITLE
chore: add second confirmation for container data loss

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -28,6 +28,10 @@ If you simply want to reset the Kubernetes cluster, run 'colima kubernetes reset
 			if !y {
 				return nil
 			}
+			yy := cli.Prompt("\033[31m\033[1mthis will delete ALL container data. Are you sure you want to continue")
+			if !yy {
+				return nil
+			}
 		}
 
 		return newApp().Delete()


### PR DESCRIPTION
We have observed some users not realizing container data is lost when doing delete. This change does not modify scripted behaviour, as -f / force toggles maintains same logic.