### PR TITLE
config: make persistence optional with --save-config flag

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -252,7 +252,7 @@ func (c colimaApp) SSH(args ...string) error {
 	// peek the current directory to see if it is mounted to prevent `cd` errors
 	// with limactl ssh
 	if err := func() error {
-		conf, err := limautil.InstanceConfig()
+		conf, err := configmanager.LoadInstance()
 		if err != nil {
 			return err
 		}
@@ -303,7 +303,7 @@ func (c colimaApp) Status(extended bool) error {
 	}
 
 	driver := "QEMU"
-	conf, _ := limautil.InstanceConfig()
+	conf, _ := configmanager.LoadInstance()
 	if !conf.Empty() {
 		driver = conf.DriverLabel()
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,6 +20,7 @@ import (
 	"github.com/abiosoft/colima/environment/container/docker"
 	"github.com/abiosoft/colima/environment/container/kubernetes"
 	"github.com/abiosoft/colima/util"
+	"github.com/abiosoft/colima/util/osutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -118,6 +119,7 @@ const (
 )
 
 var defaultK3sArgs = []string{"--disable=traefik"}
+var envSaveConfig = osutil.EnvVar("COLIMA_SAVE_CONFIG")
 
 var startCmdArgs struct {
 	config.Config
@@ -141,6 +143,11 @@ func init() {
 
 	mounts := strings.Join([]string{defaultMountTypeQEMU, "9p", "virtiofs"}, ", ")
 	types := strings.Join([]string{defaultVMType, "vz"}, ", ")
+
+	saveConfigDefault := true
+	if envSaveConfig.Exists() {
+		saveConfigDefault = envSaveConfig.Bool()
+	}
 
 	root.Cmd().AddCommand(startCmd)
 	startCmd.Flags().StringVarP(&startCmdArgs.Runtime, "runtime", "r", docker.Name, "container runtime ("+runtimes+")")
@@ -178,7 +185,7 @@ func init() {
 	// config
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Edit, "edit", "e", false, "edit the configuration file before starting")
 	startCmd.Flags().StringVar(&startCmdArgs.Flags.Editor, "editor", "", `editor to use for edit e.g. vim, nano, code (default "$EDITOR" env var)`)
-	startCmd.Flags().BoolVar(&startCmdArgs.Flags.SaveConfig, "save-config", true, "persist and overwrite config file with (newly) specified flags")
+	startCmd.Flags().BoolVar(&startCmdArgs.Flags.SaveConfig, "save-config", saveConfigDefault, "persist and overwrite config file with (newly) specified flags")
 
 	// mounts
 	startCmd.Flags().StringSliceVarP(&startCmdArgs.Flags.Mounts, "mount", "V", nil, "directories to mount, suffix ':w' for writable")

--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -20,11 +20,11 @@ func Save(c config.Config) error {
 
 // SaveFromFile loads configuration from file and save as config.
 func SaveFromFile(file string) error {
-	cf, err := LoadFrom(file)
+	c, err := LoadFrom(file)
 	if err != nil {
 		return err
 	}
-	return Save(cf)
+	return Save(c)
 }
 
 // SaveToFile saves configuration to file.
@@ -79,24 +79,29 @@ func ValidateConfig(c config.Config) error {
 // Error is only returned if the config file exists but could not be loaded.
 // No error is returned if the config file does not exist.
 func Load() (config.Config, error) {
-	cFile := config.CurrentProfile().File()
-	if _, err := os.Stat(cFile); err != nil {
-		oldCFile := oldConfigFile()
+	f := config.CurrentProfile().File()
+	if _, err := os.Stat(f); err != nil {
+		oldF := oldConfigFile()
 
 		// config file does not exist, check older version for backward compatibility
-		if _, err := os.Stat(oldCFile); err != nil {
+		if _, err := os.Stat(oldF); err != nil {
 			return config.Config{}, nil
 		}
 
 		// older version exists
 		logrus.Infof("settings from older %s version detected and copied", config.AppName)
-		if err := cli.Command("cp", oldCFile, cFile).Run(); err != nil {
+		if err := cli.Command("cp", oldF, f).Run(); err != nil {
 			logrus.Warn(fmt.Errorf("error copying config: %w, proceeding with defaults", err))
 			return config.Config{}, nil
 		}
 	}
 
-	return LoadFrom(cFile)
+	return LoadFrom(f)
+}
+
+// LoadInstance is like Load but returns the config of the currently running instance.
+func LoadInstance() (config.Config, error) {
+	return LoadFrom(config.CurrentProfile().StateFile())
 }
 
 // Teardown deletes the config.

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -182,7 +182,7 @@ func (l limaVM) Stop(ctx context.Context, force bool) error {
 	a.Stage("stopping")
 
 	if util.MacOS() {
-		conf, _ := limautil.InstanceConfig()
+		conf, _ := configmanager.LoadInstance()
 		a.Retry("", time.Second*1, 10, func(retryCount int) error {
 			err := l.daemon.Stop(ctx, conf)
 			if err != nil {
@@ -208,7 +208,7 @@ func (l limaVM) Teardown(ctx context.Context) error {
 	a := l.Init(ctx)
 
 	if util.MacOS() {
-		conf, _ := limautil.InstanceConfig()
+		conf, _ := configmanager.LoadInstance()
 		a.Retry("", time.Second*1, 10, func(retryCount int) error {
 			return l.daemon.Stop(ctx, conf)
 		})
@@ -300,7 +300,7 @@ func (l *limaVM) setDiskImage() error {
 
 func (l *limaVM) syncDiskSize(ctx context.Context, conf config.Config) config.Config {
 	log := l.Logger(ctx)
-	instance, err := limautil.InstanceConfig()
+	instance, err := configmanager.LoadInstance()
 	if err != nil {
 		// instance config missing, ignore
 		return conf

--- a/environment/vm/lima/limautil/instance.go
+++ b/environment/vm/lima/limautil/instance.go
@@ -16,15 +16,6 @@ func Instance() (InstanceInfo, error) {
 	return getInstance(config.CurrentProfile().ID)
 }
 
-// InstanceConfig returns the current instance config.
-func InstanceConfig() (config.Config, error) {
-	i, err := Instance()
-	if err != nil {
-		return config.Config{}, err
-	}
-	return i.Config()
-}
-
 // InstanceInfo is the information about a Lima instance
 type InstanceInfo struct {
 	Name    string `json:"name,omitempty"`

--- a/environment/vm/lima/network.go
+++ b/environment/vm/lima/network.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/config/configmanager"
 	"github.com/abiosoft/colima/embedded"
 	"github.com/abiosoft/colima/environment/vm/lima/limautil"
 	"github.com/abiosoft/colima/util"
@@ -39,7 +40,7 @@ func (l *limaVM) replicateHostAddresses(conf config.Config) error {
 }
 
 func (l *limaVM) removeHostAddresses() {
-	conf, _ := limautil.InstanceConfig()
+	conf, _ := configmanager.LoadInstance()
 	if !conf.Network.Address && conf.Network.HostAddresses {
 		for _, ip := range util.HostIPAddresses() {
 			_ = l.RunQuiet("sudo", "ip", "address", "del", ip.String()+"/24", "dev", "lo")

--- a/util/osutil/os.go
+++ b/util/osutil/os.go
@@ -5,10 +5,31 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
+
+// EnvVar is environment variable
+type EnvVar string
+
+// Exists checks if the environment variable has been set.
+func (e EnvVar) Exists() bool {
+	_, ok := os.LookupEnv(string(e))
+	return ok
+}
+
+// Bool returns the environment variable value as boolean.
+func (e EnvVar) Bool() bool {
+	ok, _ := strconv.ParseBool(e.Val())
+	return ok
+}
+
+// Bool returns the environment variable value.
+func (e EnvVar) Val() string {
+	return os.Getenv(string(e))
+}
 
 const EnvColimaBinary = "COLIMA_BINARY"
 


### PR DESCRIPTION
This introduces a new `--save-config` flag which defaults to true.

To prevent Colima from overriding configuration settings, `--save-config=false` should be specified for `colima start`.

As an alternative option, `COLIMA_SAVE_CONFIG=0` environment variable can be set.

Fixes #613.
