### PR TITLE
docker: avoid error where the cache docker-certs directory does not exist

### DIFF
--- a/environment/vm/lima/certs.go
+++ b/environment/vm/lima/certs.go
@@ -23,7 +23,7 @@ func (l limaVM) copyCerts() error {
 
 		// copy to cache dir
 		dockerCertsCacheDir := filepath.Join(config.CacheDir(), "docker-certs")
-		if err := l.host.RunQuiet("rm", "-r", dockerCertsCacheDir); err != nil {
+		if err := l.host.RunQuiet("rm", "-rf", dockerCertsCacheDir); err != nil {
 			return err
 		}
 		if err := l.host.RunQuiet("mkdir", "-p", dockerCertsCacheDir); err != nil {


### PR DESCRIPTION
Added force argument to avoid an issue where the directory does not exist yet.

Fixes #1128