### PR TITLE
vm: add support for custom disk images

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -163,7 +163,7 @@ func init() {
 	startCmd.Flags().StringVarP(&startCmdArgs.Arch, "arch", "a", defaultArch, "architecture (aarch64, x86_64)")
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Foreground, "foreground", "f", false, "Keep colima in the foreground")
 	startCmd.Flags().StringVar(&startCmdArgs.Hostname, "hostname", "", "custom hostname for the virtual machine")
-	startCmd.Flags().StringVarP(&startCmdArgs.DiskImage, "disk-image", "i", "", "local path or URL to a custom disk image")
+	startCmd.Flags().StringVarP(&startCmdArgs.DiskImage, "disk-image", "i", "", "file path to a custom disk image")
 
 	// host IP addresses
 	startCmd.Flags().BoolVar(&startCmdArgs.Network.HostAddresses, "network-host-addresses", false, "support port forwarding to specific host IP addresses")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -163,6 +163,7 @@ func init() {
 	startCmd.Flags().StringVarP(&startCmdArgs.Arch, "arch", "a", defaultArch, "architecture (aarch64, x86_64)")
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Foreground, "foreground", "f", false, "Keep colima in the foreground")
 	startCmd.Flags().StringVar(&startCmdArgs.Hostname, "hostname", "", "custom hostname for the virtual machine")
+	startCmd.Flags().StringVarP(&startCmdArgs.DiskImage, "disk-image", "i", "", "local path or URL to a custom disk image")
 
 	// host IP addresses
 	startCmd.Flags().BoolVar(&startCmdArgs.Network.HostAddresses, "network-host-addresses", false, "support port forwarding to specific host IP addresses")

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	VMType               string `yaml:"vmType,omitempty"`
 	VZRosetta            bool   `yaml:"rosetta,omitempty"`
 	NestedVirtualization bool   `yaml:"nestedVirtualization,omitempty"`
+	DiskImage            string `yaml:"diskImage,omitempty"`
 
 	// volume mounts
 	Mounts       []Mount `yaml:"mounts,omitempty"`

--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/abiosoft/colima/cli"
 	"github.com/abiosoft/colima/config"
@@ -74,6 +75,12 @@ func ValidateConfig(c config.Config) error {
 	if c.VMType == "qemu" {
 		if err := util.AssertQemuImg(); err != nil {
 			return fmt.Errorf("cannot use vmType: '%s', error: %w", c.VMType, err)
+		}
+	}
+
+	if c.DiskImage != "" {
+		if strings.HasPrefix(c.DiskImage, "http://") || strings.HasPrefix(c.DiskImage, "https://") {
+			return fmt.Errorf("cannot use diskImage: remote URLs not supported, only local files can be specified")
 		}
 	}
 

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -197,6 +197,14 @@ sshPort: 0
 # Default: []
 mounts: []
 
+# Specify a custom disk image for the virtual machine.
+# When not specified, Colima downloads the disk image from Github at
+# https://github.com/abiosoft/colima-core/releases.
+# A custom disk image (local disk path or URL) can be specified to override the behaviour.
+#
+# Default: ""
+diskImage: ""
+
 # Environment variables for the virtual machine.
 #
 # EXAMPLE

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -198,9 +198,9 @@ sshPort: 0
 mounts: []
 
 # Specify a custom disk image for the virtual machine.
-# When not specified, Colima downloads the disk image from Github at
+# When not specified, Colima downloads an appropriate disk image from Github at
 # https://github.com/abiosoft/colima-core/releases.
-# A custom disk image (local disk path or URL) can be specified to override the behaviour.
+# The file path to a custom disk image can be specified to override the behaviour.
 #
 # Default: ""
 diskImage: ""

--- a/environment/vm/lima/limautil/image.go
+++ b/environment/vm/lima/limautil/image.go
@@ -53,6 +53,11 @@ func findImage(arch environment.Arch, runtime string) (f limaconfig.File, err er
 	return img, nil
 }
 
+// Image returns the details of the disk image to download for the arch and runtime.
+func Image(arch environment.Arch, runtime string) (limaconfig.File, error) {
+	return findImage(arch, runtime)
+}
+
 // DownloadImage downloads the image for arch and runtime.
 func DownloadImage(arch environment.Arch, runtime string) (f limaconfig.File, err error) {
 	img, err := findImage(arch, runtime)

--- a/util/downloader/sha.go
+++ b/util/downloader/sha.go
@@ -17,10 +17,11 @@ type SHA struct {
 // ValidateFile validates the SHA of the file.
 func (s SHA) ValidateFile(host hostActions, file string) error {
 	dir, filename := filepath.Split(file)
+	digest := strings.TrimPrefix(s.Digest, fmt.Sprintf("sha%d:", s.Size))
 
 	script := strings.NewReplacer(
 		"{dir}", dir,
-		"{digest}", s.Digest,
+		"{digest}", digest,
 		"{size}", strconv.Itoa(s.Size),
 		"{filename}", filename,
 	).Replace(
@@ -33,10 +34,6 @@ func (s SHA) ValidateFile(host hostActions, file string) error {
 func (s SHA) validateDownload(host hostActions, url string, filename string) error {
 	if s.URL == "" && s.Digest == "" {
 		return fmt.Errorf("error validating SHA: one of Digest or URL must be set")
-	}
-
-	if s.Digest != "" {
-		s.Digest = strings.TrimPrefix(s.Digest, fmt.Sprintf("sha%d:", s.Size))
 	}
 
 	// fetch digest from URL if empty

--- a/util/downloader/sha.go
+++ b/util/downloader/sha.go
@@ -1,0 +1,75 @@
+package downloader
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// SHA is the shasum of a file.
+type SHA struct {
+	Digest string // shasum
+	URL    string // url to download the shasum file (if Digest is empty)
+	Size   int    // one of 256 or 512
+}
+
+// ValidateFile validates the SHA of the file.
+func (s SHA) ValidateFile(host hostActions, file string) error {
+	dir, filename := filepath.Split(file)
+
+	script := strings.NewReplacer(
+		"{dir}", dir,
+		"{digest}", s.Digest,
+		"{size}", strconv.Itoa(s.Size),
+		"{filename}", filename,
+	).Replace(
+		`cd {dir} && echo "{digest}  {filename}" | shasum -a {size} --check --status`,
+	)
+
+	return host.Run("sh", "-c", script)
+}
+
+func (s SHA) validateDownload(host hostActions, url string, filename string) error {
+	if s.URL == "" && s.Digest == "" {
+		return fmt.Errorf("error validating SHA: one of Digest or URL must be set")
+	}
+
+	if s.Digest != "" {
+		s.Digest = strings.TrimPrefix(s.Digest, fmt.Sprintf("sha%d:", s.Size))
+	}
+
+	// fetch digest from URL if empty
+	if s.Digest == "" {
+		// retrieve the filename from the download url.
+		filename := func() string {
+			if url == "" {
+				return ""
+			}
+			split := strings.Split(url, "/")
+			return split[len(split)-1]
+		}()
+
+		digest, err := fetchSHAFromURL(host, s.URL, filename)
+		if err != nil {
+			return err
+		}
+		s.Digest = digest
+	}
+
+	return s.ValidateFile(host, filename)
+}
+
+func fetchSHAFromURL(host hostActions, url, filename string) (string, error) {
+	script := strings.NewReplacer(
+		"{url}", url,
+		"{filename}", filename,
+	).Replace(
+		"curl -sL {url} | grep '  {filename}$' | awk -F' ' '{print $1}'",
+	)
+	sha, err := host.RunOutput("sh", "-c", script)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving sha from url '%s': %w", url, err)
+	}
+	return strings.TrimSpace(sha), nil
+}


### PR DESCRIPTION
### Details

This PR adds support for specifying a disk image on the local disk. 
Users can now manually download the Colima disk image and specify the path to the downloaded file.

### Usage

```
colima start --disk-image ~/Downloads/ubuntu-24.04-minimal-cloudimg-arm64-docker.qcow2
```