### PR TITLE
cli: add quotes to k3s-arg example for colima start

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -45,7 +45,7 @@ Run 'colima template' to set the default configurations or 'colima start --edit'
 		"  colima start --arch aarch64\n" +
 		"  colima start --dns 1.1.1.1 --dns 8.8.8.8\n" +
 		"  colima start --dns-host example.com=1.2.3.4\n" +
-		"  colima start --kubernetes --k3s-arg=--disable=coredns,servicelb,traefik,local-storage,metrics-server",
+		"  colima start --kubernetes --k3s-arg=\"--disable=coredns,servicelb,traefik,local-storage,metrics-server\"",
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()


### PR DESCRIPTION
```
change fixes quotation error in colima start command for k3s-arg flag
```

![Screenshot 2024-12-27 at 02 08 28](https://github.com/user-attachments/assets/91a377af-0de4-44d5-9822-24c29b73bbd7)



issue https://github.com/abiosoft/colima/issues/1229