### PR TITLE
chore: fix copyright license year (Revert #1235)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Abiola Ibrahim
+Copyright (c) 2021 Abiola Ibrahim
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This reverts commit 431146a84d9100e9866762cc621ea64bdbc8a16c. (deleted pr: https://github.com/abiosoft/colima/pull/1235)

Copyright years are not to be updated.

https://courier.unesco.org/en/articles/universal-copyright-convention

> It prescribes that the formalities required by the national law of a contracting state shall be considered to be satisfied if all the copies of a work originating in another contracting state carry the symbol ©, accompanied by the name of the copyright owner and **the year of first publication**.

The person who made this change, @JasonnnW3000, had [created other similar Pull Requests for other famous OSS project](https://github.com/orgs/community/discussions/148296). Therefore, it appears that the account is currently suspended and deleted pull request.

