### PR TITLE
chore: log possible error while reading config file

### DIFF
--- a/environment/vm/lima/config.go
+++ b/environment/vm/lima/config.go
@@ -15,7 +15,7 @@ func (l limaVM) getConf() map[string]string {
 	obj := map[string]string{}
 	b, err := l.Read(configFile)
 	if err != nil {
-		log.Tracef("failed to read config file %v", err)
+		log.Trace(fmt.Errorf("error reading config file: %w", err))
 
 		return obj
 	}

--- a/environment/vm/lima/config.go
+++ b/environment/vm/lima/config.go
@@ -1,6 +1,7 @@
 package lima
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -9,9 +10,13 @@ import (
 const configFile = "/etc/colima/colima.json"
 
 func (l limaVM) getConf() map[string]string {
+	log := l.Logger(context.Background())
+
 	obj := map[string]string{}
 	b, err := l.Read(configFile)
 	if err != nil {
+		log.Tracef("failed to read config file %v", err)
+
 		return obj
 	}
 


### PR DESCRIPTION
```
change logs actual error when trying to read Colima config file
```

Issue can be found [here](https://github.com/abiosoft/colima/issues/1239).