### PR TITLE
core: config initial value for kubernetes version if empty in yaml

### DIFF
--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -104,6 +104,12 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 		conf = c.config()
 	}
 
+	if conf.Version == "" {
+		// this ensure if `version` tag in `kubernetes` section in yaml is empty,
+		// it should assign with the `DefaultVersion` for the baseURL
+		conf.Version = DefaultVersion
+	}
+
 	if c.isVersionInstalled(conf.Version) {
 		// runtime has changed, ensure the required images are in the registry
 		if currentRuntime := c.runtime(); currentRuntime != "" && currentRuntime != runtime {


### PR DESCRIPTION
According to facing the error while using the `containerd` as runtime and enable `kubernetes` features as the following:

```
FATA[0018] error provisioning kubernetes: error at 'downloading and installing': error downloading 'https://github.com/k3s-io/k3s/releases/download//k3s': error validating SHA sum for 'k3s': exit status 1 
```
It turns out missing `version` string in baseURL which goes with `environment/container/kubernetes/k3s.go`

Thus make a if-else statement for setup `DefaultVersion` which declares in `environment/container/kubernetes/kubernetes.go`