### PR TITLE
k8s: update latest version for default kubernetes release

### DIFF
--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	Name           = "kubernetes"
-	DefaultVersion = "v1.31.2+k3s1"
+	DefaultVersion = "v1.32.0+k3s1"
 
 	ConfigKey = "kubernetes_config"
 )

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -104,6 +104,12 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 		conf = c.config()
 	}
 
+	if conf.Version == "" {
+		// this ensure if `version` tag in `kubernetes` section in yaml is empty,
+		// it should assign with the `DefaultVersion` for the baseURL
+		conf.Version = DefaultVersion
+	}
+
 	if c.isVersionInstalled(conf.Version) {
 		// runtime has changed, ensure the required images are in the registry
 		if currentRuntime := c.runtime(); currentRuntime != "" && currentRuntime != runtime {


### PR DESCRIPTION
As subject mentioned, just a small change updating the default version string.