### PR TITLE
chore: expend the path information about current profile being used

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -99,7 +99,8 @@ func (c colimaApp) startWithRuntime(conf config.Config) ([]environment.Container
 func (c colimaApp) Start(conf config.Config) error {
 	ctx := context.WithValue(context.Background(), config.CtxKey(), conf)
 
-	// this tells the full path of current profile being used, instead of misunderstanding it as a template default profile
+	log.Println("starting", config.CurrentProfile().DisplayName)
+	// print the full path of current profile being used
 	log.Tracef("starting with config file: %s\n", config.CurrentProfile().File())
 
 	var containers []environment.Container


### PR DESCRIPTION
Revision of #1267.

As subject mentioned, according to mistaken config yaml which modified manually, it might be showing the full path about the current profile being used with command `$ colima start` as well.