### PR TITLE
incus: remove core.https_address from default config

### DIFF
--- a/environment/container/incus/config.yaml
+++ b/environment/container/incus/config.yaml
@@ -1,5 +1,3 @@
-config:
-  core.https_address: '[::]:8443'
 networks:
   - config:
       ipv4.address: 192.100.0.1/24


### PR DESCRIPTION
The purpose of specifying the `core.https_address` by default is to expose the Web UI. 
However, from Incus 6.7, the Web UI is accessible with the `incus webui` command.