### PR TITLE
docker: replace also localhost with host gateway ip in docker daemon.json

### DIFF
--- a/environment/container/docker/daemon.go
+++ b/environment/container/docker/daemon.go
@@ -29,7 +29,7 @@ func getHostGatewayIp(d dockerRuntime, conf map[string]any) (string, error) {
 	return ip, nil
 }
 
-func resolveHostProxy(hostProxy string, hostGateway string) (string) {
+func resolveHostProxy(hostProxy, hostGateway string) string {
 	u, err := url.Parse(hostProxy)
 	if err != nil {
 		return hostProxy
@@ -46,6 +46,7 @@ func resolveHostProxy(hostProxy string, hostGateway string) (string) {
 			}
 			u.Host = newHost
 			hostProxy = u.String()
+			break
 		}
 	}
 	return hostProxy


### PR DESCRIPTION
This improves PR #1145 by replacing any loopback address, not only _127.0.0.1_ but also _localhost_ with the host gateway.
In my case my proxy is configured as localhost, and it listens both on 127.0.0.1 (IPv4) and ::1 (IPv6).

The implementation logic is the same as in [lima](https://github.com/lima-vm/lima/blob/0625d0b084450e874869dcbc9f63d4312797c3fe/pkg/cidata/cidata.go#L73).

This addresses issue #956.

In my opinion in _no-proxy_ env variable references to localhost should not be replaced, because in this case it refers to the loopback of the container.