### PR TITLE
vm: make binfmt emulation configurable

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -168,6 +168,8 @@ func init() {
 	// host IP addresses
 	startCmd.Flags().BoolVar(&startCmdArgs.Network.HostAddresses, "network-host-addresses", false, "support port forwarding to specific host IP addresses")
 
+	binfmtDesc := "use binfmt for foreign architecture emulation"
+
 	if util.MacOS() {
 		// network address
 		startCmd.Flags().BoolVar(&startCmdArgs.Network.Address, "network-address", false, "assign reachable IP address to the VM")
@@ -177,6 +179,7 @@ func init() {
 			startCmd.Flags().StringVarP(&startCmdArgs.VMType, "vm-type", "t", defaultVMType, "virtual machine type ("+types+")")
 			if util.MacOS13OrNewerOnArm() {
 				startCmd.Flags().BoolVar(&startCmdArgs.VZRosetta, "vz-rosetta", false, "enable Rosetta for amd64 emulation")
+				binfmtDesc += " (no-op if Rosetta is enabled)"
 			}
 		}
 
@@ -185,6 +188,9 @@ func init() {
 			startCmd.Flags().BoolVarP(&startCmdArgs.NestedVirtualization, "nested-virtualization", "z", false, "enable nested virtualization")
 		}
 	}
+
+	// binfmt
+	startCmd.Flags().BoolVar(&startCmdArgs.Binfmt, "binfmt", true, binfmtDesc)
 
 	// config
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Edit, "edit", "e", false, "edit the configuration file before starting")

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	// VM
 	VMType               string `yaml:"vmType,omitempty"`
 	VZRosetta            bool   `yaml:"rosetta,omitempty"`
+	Binfmt               bool   `yaml:"binfmt,omitempty"`
 	NestedVirtualization bool   `yaml:"nestedVirtualization,omitempty"`
 	DiskImage            string `yaml:"diskImage,omitempty"`
 

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -125,6 +125,10 @@ vmType: qemu
 # Default: false
 rosetta: false
 
+# Enable foreign architecture emulation via binfmt (e.g. amd64 on arm64, arm64 on amd64)
+# Default: true
+binfmt: true
+
 # Enable nested virtualization for the virtual machine (requires m3 mac and vmType `vz`)
 # Default: false
 nestedVirtualization: false

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -383,9 +383,11 @@ func (l *limaVM) addPostStartActions(a *cli.ActiveCommandChain, conf config.Conf
 	a.Add(func() error {
 		if !l.limaConf.Rosetta.Enabled {
 			// use binfmt when rosetta is disabled and emulation is disabled i.e. host arch
-			if arch := environment.HostArch(); arch == environment.Arch(conf.Arch).Value() {
-				if err := core.SetupBinfmt(l.host, l, environment.Arch(conf.Arch)); err != nil {
-					logrus.Warn(fmt.Errorf("unable to enable qemu %s emulation: %w", arch, err))
+			if l.conf.Binfmt {
+				if arch := environment.HostArch(); arch == environment.Arch(conf.Arch).Value() {
+					if err := core.SetupBinfmt(l.host, l, environment.Arch(conf.Arch)); err != nil {
+						logrus.Warn(fmt.Errorf("unable to enable qemu %s emulation: %w", arch, err))
+					}
 				}
 			}
 


### PR DESCRIPTION
As ed49fef4ad63ec48055b4b230ecbad00c54f5417 did for Rosetta, this change adds a flag to control whether binfmt emulation is setup.

In the future, I think it'd be interesting to consider making the option's type `[]string | bool`, where `true` keeps the default behavior of automatically picking the architectures to enable, `false` disables binfmt setup, and a list will let the user define which architectures to emulate. (I'd be happy to do this here if you'd like, I think it may be the better solution. :))