### PR TITLE
Reset formatting modes at the end of delete prompt

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -67,6 +67,7 @@ func quotedArgs(args []string) string {
 func Prompt(question string) bool {
 	fmt.Print(question)
 	fmt.Print("? [y/N] ")
+	fmt.Print("\033[0m") // reset all formatting modes (if any) used by the question string 
 
 	var answer string
 	_, _ = fmt.Scanln(&answer)

--- a/util/fsutil/fs.go
+++ b/util/fsutil/fs.go
@@ -34,7 +34,7 @@ func (DefaultFS) Open(name string) (fs.File, error) { return os.Open(name) }
 func (DefaultFS) MkdirAll(path string, perm fs.FileMode) error { return os.MkdirAll(path, perm) }
 
 // FakeFS is a mock FS. The following can be done in a test before usage.
-//  osutil.FS = osutil.FakeFS
+// osutil.FS = osutil.FakeFS
 var FakeFS FileSystem = fakeFS{}
 
 type fakeFS struct{}


### PR DESCRIPTION
Currently, the second prompt for the delete command uses a bold + red format mode using escape codes. However, this mode is not reset at the end and ends up leaking unto next lines on the terminal.

This behaviour has been detailed in issue #1319. 

Includes a fmt change too.

Before:
![image](https://github.com/user-attachments/assets/d2f19255-388b-4711-bde9-73edc695c397)

After (built and tested locally):
<img width="753" alt="image" src="https://github.com/user-attachments/assets/da0ecbc4-c57b-4b61-ab84-5ec2725421b9" />