### PR TITLE
Properly reset formatting at the end of question prompts

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -67,6 +67,7 @@ func quotedArgs(args []string) string {
 func Prompt(question string) bool {
 	fmt.Print(question)
 	fmt.Print("? [y/N] ")
+	fmt.Print("\033[0m") // reset all formatting modes (if any) used by the question string
 
 	var answer string
 	_, _ = fmt.Scanln(&answer)

--- a/util/fsutil/fs.go
+++ b/util/fsutil/fs.go
@@ -34,7 +34,7 @@ func (DefaultFS) Open(name string) (fs.File, error) { return os.Open(name) }
 func (DefaultFS) MkdirAll(path string, perm fs.FileMode) error { return os.MkdirAll(path, perm) }
 
 // FakeFS is a mock FS. The following can be done in a test before usage.
-//  osutil.FS = osutil.FakeFS
+// osutil.FS = osutil.FakeFS
 var FakeFS FileSystem = fakeFS{}
 
 type fakeFS struct{}

--- a/util/fsutil/fs.go
+++ b/util/fsutil/fs.go
@@ -34,7 +34,7 @@ func (DefaultFS) Open(name string) (fs.File, error) { return os.Open(name) }
 func (DefaultFS) MkdirAll(path string, perm fs.FileMode) error { return os.MkdirAll(path, perm) }
 
 // FakeFS is a mock FS. The following can be done in a test before usage.
-// osutil.FS = osutil.FakeFS
+//   osutil.FS = osutil.FakeFS
 var FakeFS FileSystem = fakeFS{}
 
 type fakeFS struct{}


### PR DESCRIPTION
As illustrated in issue #1319, the second prompt for the delete command uses a bold + red format mode using escape codes. However, this mode is not reset at the end and ends up leaking unto next lines on the terminal.

This change will make sure all `question` strings passed to the `Prompt` function will be closed properly by a reset escape sequence.

Includes a fmt change too.

Before:
![bug1](https://github.com/user-attachments/assets/fee0f25a-a37e-4783-a301-58e53092e944)

After:
![bug2](https://github.com/user-attachments/assets/17432c46-67cb-44b7-98c1-577bdc01314c)