### PR TITLE
chore: reorganize dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,27 +4,23 @@ go 1.20
 
 require (
 	github.com/coreos/go-semver v0.3.1
+	github.com/docker/go-units v0.5.0
 	github.com/fatih/color v1.18.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/rjeczalik/notify v0.9.3
+	github.com/sevlyar/go-daemon v0.1.6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/term v0.29.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/stretchr/testify v1.8.4 // indirect
-
 require (
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
-	github.com/sevlyar/go-daemon v0.1.6
-)
-
-require (
-	github.com/docker/go-units v0.5.0
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 )


### PR DESCRIPTION
The PR tidies up dependencies in `go.mod` by splitting `require` into two sections:

1) direct dependencies;
2) indirect dependencies.