### PR TITLE
vm: support UDP port forwarding

### DIFF
--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -32,9 +32,8 @@ func New(host environment.HostActions) environment.VM {
 	var envs []string
 	envHome := limautil.EnvLimaHome + "=" + limaHome
 	envLimaInstance := envLimaInstance + "=" + config.CurrentProfile().ID
-	envSSHForward := envLimaSSHForwarder + "=" + osutil.EnvVar(envLimaSSHForwarder).ValOr("true")
 	envBinary := osutil.EnvColimaBinary + "=" + osutil.Executable()
-	envs = append(envs, envHome, envLimaInstance, envSSHForward, envBinary)
+	envs = append(envs, envHome, envLimaInstance, envBinary)
 
 	// consider making this truly flexible to support other VMs
 	return &limaVM{
@@ -46,10 +45,9 @@ func New(host environment.HostActions) environment.VM {
 }
 
 const (
-	envLimaInstance     = "LIMA_INSTANCE"
-	envLimaSSHForwarder = "LIMA_SSH_PORT_FORWARDER"
-	lima                = "lima"
-	limactl             = limautil.LimactlCommand
+	envLimaInstance = "LIMA_INSTANCE"
+	lima            = "lima"
+	limactl         = limautil.LimactlCommand
 )
 
 var _ environment.VM = (*limaVM)(nil)

--- a/environment/vm/lima/limaconfig/config.go
+++ b/environment/vm/lima/limaconfig/config.go
@@ -78,6 +78,7 @@ type (
 
 const (
 	TCP Proto = "tcp"
+	UDP Proto = "udp"
 
 	REVSSHFS MountType = "reverse-sshfs"
 	NINEP    MountType = "9p"

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -258,6 +258,14 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 				HostPortRange:     [2]int{1, 65535},
 				Proto:             limaconfig.TCP,
 			},
+			limaconfig.PortForward{
+				GuestIPMustBeZero: true,
+				GuestIP:           net.ParseIP("0.0.0.0"),
+				GuestPortRange:    [2]int{1, 65535},
+				HostIP:            net.ParseIP("0.0.0.0"),
+				HostPortRange:     [2]int{1, 65535},
+				Proto:             limaconfig.UDP,
+			},
 		)
 		// bind 127.0.0.1
 		l.PortForwards = append(l.PortForwards,
@@ -267,6 +275,13 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 				HostIP:         net.ParseIP("127.0.0.1"),
 				HostPortRange:  [2]int{1, 65535},
 				Proto:          limaconfig.TCP,
+			},
+			limaconfig.PortForward{
+				GuestIP:        net.ParseIP("127.0.0.1"),
+				GuestPortRange: [2]int{1, 65535},
+				HostIP:         net.ParseIP("127.0.0.1"),
+				HostPortRange:  [2]int{1, 65535},
+				Proto:          limaconfig.UDP,
 			},
 		)
 


### PR DESCRIPTION
Should fix #1292 and fix #1300, and maybe others

gRPC port forwarder is considered stable in lima, no need to force older SSH forwarder by default