### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/environment/vm/lima/file.go
+++ b/environment/vm/lima/file.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
+	"math"
 	"github.com/abiosoft/colima/environment"
 )
 
@@ -58,8 +58,11 @@ func newFileInfo(guest environment.GuestActions, filename string) (fileInfo, err
 	info.name = filename
 	info.size, _ = strconv.ParseInt(stats[0], 10, 64)
 	info.mode = func() fs.FileMode {
-		mode, _ := strconv.Atoi(stats[1])
-		return fs.FileMode(mode)
+		perm, err := strconv.ParseUint(stats[1], 10, 32)
+		if err != nil || perm > math.MaxUint32 {
+			return 0
+		}
+		return fs.FileMode(perm)
 	}()
 	info.modTime = func() time.Time {
 		unix, _ := strconv.ParseInt(stats[2], 10, 64)

--- a/environment/vm/lima/file.go
+++ b/environment/vm/lima/file.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"math"
 	"github.com/abiosoft/colima/environment"
 )
 
@@ -58,11 +57,8 @@ func newFileInfo(guest environment.GuestActions, filename string) (fileInfo, err
 	info.name = filename
 	info.size, _ = strconv.ParseInt(stats[0], 10, 64)
 	info.mode = func() fs.FileMode {
-		perm, err := strconv.ParseUint(stats[1], 10, 32)
-		if err != nil || perm > math.MaxUint32 {
-			return 0
-		}
-		return fs.FileMode(perm)
+		mode, _ := strconv.ParseUint(stats[1], 10, 32)
+		return fs.FileMode(mode)
 	}()
 	info.modTime = func() time.Time {
 		unix, _ := strconv.ParseInt(stats[2], 10, 64)


### PR DESCRIPTION
Potential fix for [https://github.com/abiosoft/colima/security/code-scanning/7](https://github.com/abiosoft/colima/security/code-scanning/7)

To fix the problem, we should ensure that the value parsed from `stats[1]` is within the valid range for `fs.FileMode` (i.e., between 0 and `math.MaxUint32`) before converting it. We should also handle errors from `strconv.Atoi` to avoid using invalid values. The best way to do this is to use `strconv.ParseUint` with a bit size of 32, which will only succeed for valid, non-negative values within the range of a `uint32`. If parsing fails or the value is out of bounds, we should return an error or a default value. The changes are needed in the anonymous function assigned to `info.mode` in the `newFileInfo` function (lines 60-63). We also need to import the `math` package for the constant `math.MaxUint32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
