### PR TITLE
k3s: allow overriding default k3s args

### DIFF
--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -23,6 +23,9 @@ func hasK3sArg(k3sArgs []string, argName string) bool {
 		if strings.HasPrefix(arg, argName+"=") {
 			return true
 		}
+		if strings.HasPrefix(arg, argName+" ") {
+			return true
+		}
 		if arg == argName {
 			return true
 		}


### PR DESCRIPTION
Fixes #1363 and relates to #1362.

I went through all the arguments being passed by Colima to k3s to see which ones seemed reasonable to be able to override, and only found these two. Before this change, passing `--k3s-arg="--advertise-address=127.0.0.2"` would just add that argument so that the actual parameters to k3s would be something like `--advertise-address=127.0.0.2 --advertise-address=192.168.0.5`, with the latter one being set by Colima.