### PR TITLE
k3s: retry ip address retrieval during setup

### DIFF
--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -157,7 +157,7 @@ func installK3sCluster(
 		"--write-kubeconfig-mode", "644",
 	}, k3sArgs...)
 
-	a.Retry("waiting for VM IP address", time.Second*2, 10, func(retryCount int) error {
+	a.Retry("waiting for VM IP address", time.Second*5, 4, func(retryCount int) error {
 		ipAddress := limautil.IPAddress(config.CurrentProfile().ID)
 		if ipAddress == "" {
 			return fmt.Errorf("no IP address assigned to network interface")


### PR DESCRIPTION
When networking is enabled but the interface does not have any IP assigned yet, k3s installation can fail. The `IPAddress` function says that it is guaranteed to return a value, which is technically true, but that value can be an empty string if the network interface exists but doesn't have any IP assigned.

This changes the k3s installation to wait for up to 20 seconds for an address to be assigned before failing.

Fixes #1373