### PR TITLE
cli: default template flag to true.

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -172,7 +172,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Foreground, "foreground", "f", false, "Keep colima in the foreground")
 	startCmd.Flags().StringVar(&startCmdArgs.Hostname, "hostname", "", "custom hostname for the virtual machine")
 	startCmd.Flags().StringVarP(&startCmdArgs.DiskImage, "disk-image", "i", "", "file path to a custom disk image")
-	startCmd.Flags().BoolVar(&startCmdArgs.Flags.Template, "template", false, "use the template file for initial configuration")
+	startCmd.Flags().BoolVar(&startCmdArgs.Flags.Template, "template", true, "use the template file for initial configuration")
 
 	// retain cpu flag for backward compatibility
 	startCmd.Flags().IntVar(&startCmdArgs.Flags.LegacyCPU, "cpu", defaultCPU, "number of CPUs")


### PR DESCRIPTION
This PR reinstates the previous behaviour of loading config from the template file (when present).

Template use can still be disabled with `colima start --template=false`.