### PR TITLE
vm: make port forwarder configurable

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -174,6 +174,9 @@ func init() {
 	startCmd.Flags().StringVarP(&startCmdArgs.DiskImage, "disk-image", "i", "", "file path to a custom disk image")
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.Template, "template", true, "use the template file for initial configuration")
 
+	// port forwarder
+	startCmd.Flags().StringVar(&startCmdArgs.PortForwarder, "port-forwarder", "ssh", "port forwarder to use (ssh, grpc)")
+
 	// retain cpu flag for backward compatibility
 	startCmd.Flags().IntVar(&startCmdArgs.Flags.LegacyCPU, "cpu", defaultCPU, "number of CPUs")
 	startCmd.Flag("cpu").Hidden = true
@@ -489,6 +492,9 @@ func prepareConfig(cmd *cobra.Command) {
 	}
 	if !cmd.Flag("ssh-port").Changed {
 		startCmdArgs.SSHPort = current.SSHPort
+	}
+	if !cmd.Flag("port-forwarder").Changed {
+		startCmdArgs.PortForwarder = current.PortForwarder
 	}
 	if !cmd.Flag("dns").Changed {
 		startCmdArgs.Network.DNSResolvers = current.Network.DNSResolvers

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	Binfmt               *bool  `yaml:"binfmt,omitempty"`
 	NestedVirtualization bool   `yaml:"nestedVirtualization,omitempty"`
 	DiskImage            string `yaml:"diskImage,omitempty"`
+	PortForwarder        string `yaml:"portForwarder,omitempty"` // "ssh", "grpc"
 
 	// volume mounts
 	Mounts       []Mount `yaml:"mounts,omitempty"`

--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -59,6 +59,8 @@ func LoadFrom(file string) (config.Config, error) {
 // ValidateConfig validates config before we use it
 func ValidateConfig(c config.Config) error {
 	validMountTypes := map[string]bool{"9p": true, "sshfs": true}
+	validPortForwarders := map[string]bool{"grpc": true, "ssh": true}
+
 	if util.MacOS13OrNewer() {
 		validMountTypes["virtiofs"] = true
 	}
@@ -82,6 +84,10 @@ func ValidateConfig(c config.Config) error {
 		if strings.HasPrefix(c.DiskImage, "http://") || strings.HasPrefix(c.DiskImage, "https://") {
 			return fmt.Errorf("cannot use diskImage: remote URLs not supported, only local files can be specified")
 		}
+	}
+
+	if _, ok := validPortForwarders[c.PortForwarder]; !ok {
+		return fmt.Errorf("invalid port forwarder: '%s'", c.PortForwarder)
 	}
 
 	return nil

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -133,6 +133,13 @@ docker: {}
 # Default: qemu
 vmType: qemu
 
+# Port forwarder for the virtual machine (ssh, grpc).
+# ssh is more stable but supports only TCP.
+# grpc supports both TCP and UDP, but is experimental.
+#
+# Default: ssh
+portForwarder: ssh
+
 # Utilise rosetta for amd64 emulation (requires m1 mac and vmType `vz`)
 # Default: false
 rosetta: false

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/abiosoft/colima/cli"
@@ -77,6 +78,8 @@ func (l limaVM) Dependencies() []string {
 
 func (l *limaVM) Start(ctx context.Context, conf config.Config) error {
 	a := l.Init(ctx)
+
+	l.prepareHost(conf)
 
 	if l.Created() {
 		return l.resume(ctx, conf)
@@ -446,4 +449,12 @@ func (l *limaVM) assertQemu() error {
 		return err
 	}
 	return nil
+}
+
+const envLimaSSHPortForwarder = "LIMA_SSH_PORT_FORWARDER"
+
+func (l *limaVM) prepareHost(conf config.Config) {
+	useSSHPortForwarder := conf.PortForwarder != "grpc"
+
+	l.host = l.host.WithEnv(envLimaSSHPortForwarder + "=" + strconv.FormatBool(useSSHPortForwarder))
 }


### PR DESCRIPTION
This PR makes the port forwarder configurable https://lima-vm.io/docs/config/port/.

There is now a `--port-forwarder` flag for `colima start` and a `portForwarder` config,  with the valid options being `ssh` (default) and `grpc`.

#### Example Usage

```
colima start --port-forwarder=grpc
```

Resolves #1376