### PR TITLE
chore: update start command k3s-args example

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -45,7 +45,7 @@ Run 'colima template' to set the default configurations or 'colima start --edit'
 		"  colima start --arch aarch64\n" +
 		"  colima start --dns 1.1.1.1 --dns 8.8.8.8\n" +
 		"  colima start --dns-host example.com=1.2.3.4\n" +
-		"  colima start --kubernetes --k3s-arg=\"--disable=coredns,servicelb,traefik,local-storage,metrics-server\"",
+		"  colima start --kubernetes --k3s-arg='\"--disable=coredns,servicelb,traefik,local-storage,metrics-server\"'",
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		app := newApp()


### PR DESCRIPTION
## what
update update start command k3s-args example

## why
the `colima start --help` output does not properly output a quoted string for the `--k3s` example

## references
- #1222

## validation

updated Examples output:

```
➜  colima git:(chore/update-k3s-args) _output/binaries/colima-Darwin-arm64 start --help
Start Colima with the specified container runtime and optional kubernetes.

Colima can also be configured with a YAML file.
Run 'colima template' to set the default configurations or 'colima start --edit' to customize before startup.

Usage:
  colima start [profile] [flags]

Examples:
  colima start
  colima start --edit
  colima start --foreground
  colima start --runtime containerd
  colima start --kubernetes
  colima start --runtime containerd --kubernetes
  colima start --cpu 4 --memory 8 --disk 100
  colima start --arch aarch64
  colima start --dns 1.1.1.1 --dns 8.8.8.8
  colima start --dns-host example.com=1.2.3.4
  colima start --kubernetes --k3s-arg='"--disable=coredns,servicelb,traefik,local-storage,metrics-server"'
...
 ```

colima starting with quoted k3s-args:

```
➜  colima git:(chore/update-k3s-args) colima start --kubernetes --k3s-arg='"--disable=coredns,servicelb,traefik,local-storage,metrics-server"' -p valida
tion
INFO[0000] starting colima [profile=validation]         
INFO[0000] runtime: docker+k3s                          
INFO[0001] creating and starting ...                     context=vm
INFO[0015] provisioning ...                              context=docker
INFO[0016] starting ...                                  context=docker
INFO[0033] provisioning ...                              context=kubernetes
INFO[0034] downloading and installing ...                context=kubernetes
INFO[0039] loading oci images ...                        context=kubernetes
INFO[0044] starting ...                                  context=kubernetes
INFO[0051] updating config ...                           context=kubernetes
INFO[0051] Switched to context "colima-validation".      context=kubernetes
INFO[0052] done                                         
```

k3s node annotation and confirmation that k3s addons are not installed:

```
➜  colima git:(chore/update-k3s-args) kubectl get node colima-validation -o yaml | yq '.metadata.annotations["k3s.io/node-args"]'
["server","--write-kubeconfig-mode","644","--disable","coredns,servicelb,traefik,local-storage,metrics-server","--flannel-iface","eth0","--docker","--https-listen-port","58250"]
 ➜  colima git:(chore/update-k3s-args) kubectl get pods -n kube-system
No resources found in kube-system namespace.
```