### PR TITLE
config: consider MountPoint in checkOverlappingMounts

### DIFF
--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -389,28 +389,25 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 
 type Arch = environment.Arch
 
+func selectPath(m config.Mount) (string, error) {
+	if m.MountPoint != "" {
+		return util.CleanPath(m.MountPoint)
+	}
+
+	return util.CleanPath(m.Location)
+}
+
 func checkOverlappingMounts(mounts []config.Mount) error {
 	for i := 0; i < len(mounts)-1; i++ {
+		a, err := selectPath(mounts[i])
+		if err != nil {
+			return err
+		}
 		for j := i + 1; j < len(mounts); j++ {
-			a := mounts[i].MountPoint
-
-			if a == "" {
-				var err error
-				a, err = util.CleanPath(mounts[i].Location)
-				if err != nil {
-					return err
-				}
+			b, err := selectPath(mounts[j])
+			if err != nil {
+				return err
 			}
-
-			b := mounts[j].MountPoint
-			if b == "" {
-				var err error
-				b, err = util.CleanPath(mounts[j].Location)
-				if err != nil {
-					return err
-				}
-			}
-
 			if strings.HasPrefix(a, b) || strings.HasPrefix(b, a) {
 				return fmt.Errorf("'%s' overlaps '%s'", a, b)
 			}


### PR DESCRIPTION
# Description
Fix overlapping mount check to consider MountPoint

# Problem
The original `checkOverlappingMounts` function only checks for the `Location` field, ignoring `MountPoint`.
This causes valid mount configurations to fail when the `MountPoint` is explicitly set. For example:

```yaml
mounts:
  - location: ~/something/to/mount
    mountPoint: /opt/mount/point
    writable: true
  - location: ~/
    writable: true
```

Currently, this triggers an "overlapping mount" error even though the actual mount points do not overlap.

# Solution
Update `checkOverlappingMounts` to consider `MountPoint` in addition to `Location` when detecting overlapping mounts.
Previously, only `Location` was checked, which could incorrectly fail or allow invalid mounts when a custom `MountPoint` was used.