### PR TITLE
k3s customizable listen port

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -234,6 +234,7 @@ func init() {
 	startCmd.Flags().StringVar(&startCmdArgs.Kubernetes.Version, "kubernetes-version", defaultKubernetesVersion, "must match a k3s version https://github.com/k3s-io/k3s/releases")
 	startCmd.Flags().StringSliceVar(&startCmdArgs.Flags.LegacyKubernetesDisable, "kubernetes-disable", nil, "components to disable for k3s e.g. traefik,servicelb")
 	startCmd.Flags().StringSliceVar(&startCmdArgs.Kubernetes.K3sArgs, "k3s-arg", defaultK3sArgs, "additional args to pass to k3s")
+	startCmd.Flags().IntVar(&startCmdArgs.Kubernetes.ListenPort, "k3s-listen-port", 0, "k3s server listen port")
 	startCmd.Flag("with-kubernetes").Hidden = true
 	startCmd.Flag("kubernetes-disable").Hidden = true
 
@@ -474,6 +475,9 @@ func prepareConfig(cmd *cobra.Command) {
 	}
 	if !cmd.Flag("k3s-arg").Changed && current.Kubernetes.K3sArgs != nil {
 		startCmdArgs.Kubernetes.K3sArgs = current.Kubernetes.K3sArgs
+	}
+	if !cmd.Flag("k3s-listen-port").Changed && current.Kubernetes.ListenPort > 0 {
+		startCmdArgs.Kubernetes.ListenPort = current.Kubernetes.ListenPort
 	}
 	if !cmd.Flag("runtime").Changed {
 		startCmdArgs.Runtime = current.Runtime

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -477,7 +477,7 @@ func prepareConfig(cmd *cobra.Command) {
 		startCmdArgs.Kubernetes.K3sArgs = current.Kubernetes.K3sArgs
 	}
 	if !cmd.Flag("k3s-listen-port").Changed && current.Kubernetes.Port > 0 {
-		startCmdArgs.Kubernetes.ListenPort = current.Kubernetes.Port
+		startCmdArgs.Kubernetes.Port = current.Kubernetes.Port
 	}
 	if !cmd.Flag("runtime").Changed {
 		startCmdArgs.Runtime = current.Runtime

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -476,8 +476,8 @@ func prepareConfig(cmd *cobra.Command) {
 	if !cmd.Flag("k3s-arg").Changed && current.Kubernetes.K3sArgs != nil {
 		startCmdArgs.Kubernetes.K3sArgs = current.Kubernetes.K3sArgs
 	}
-	if !cmd.Flag("k3s-listen-port").Changed && current.Kubernetes.ListenPort > 0 {
-		startCmdArgs.Kubernetes.ListenPort = current.Kubernetes.ListenPort
+	if !cmd.Flag("k3s-listen-port").Changed && current.Kubernetes.Port > 0 {
+		startCmdArgs.Kubernetes.ListenPort = current.Kubernetes.Port
 	}
 	if !cmd.Flag("runtime").Changed {
 		startCmdArgs.Runtime = current.Runtime

--- a/colima.nix
+++ b/colima.nix
@@ -2,12 +2,12 @@
 
 with pkgs;
 
-buildGo120Module {
+buildGo123Module {
   name = "colima";
   pname = "colima";
   src = ./.;
   nativeBuildInputs = [ installShellFiles makeWrapper git ];
-  vendorSha256 = "sha256-7DIhSjHpaCyHyXKhR8KWQc2YGaD8CMq+BZHF4zIkL50=";
+  vendorHash = "sha256-ZwgzKCOEhgKK2LNRLjnWP6qHI4f6OGORvt3CREJf55I=";
   CGO_ENABLED = 1;
 
   subPackages = [ "cmd/colima" ];

--- a/config/config.go
+++ b/config/config.go
@@ -73,9 +73,10 @@ type Config struct {
 
 // Kubernetes is kubernetes configuration
 type Kubernetes struct {
-	Enabled bool     `yaml:"enabled"`
-	Version string   `yaml:"version"`
-	K3sArgs []string `yaml:"k3sArgs"`
+	Enabled    bool     `yaml:"enabled"`
+	Version    string   `yaml:"version"`
+	K3sArgs    []string `yaml:"k3sArgs"`
+	ListenPort int      `yaml:"listenPort,omitempty"`
 }
 
 // Network is VM network configuration

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ type Kubernetes struct {
 	Enabled    bool     `yaml:"enabled"`
 	Version    string   `yaml:"version"`
 	K3sArgs    []string `yaml:"k3sArgs"`
-	ListenPort int      `yaml:"port,omitempty"`
+	Port int            `yaml:"port,omitempty"`
 }
 
 // Network is VM network configuration

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ type Kubernetes struct {
 	Enabled    bool     `yaml:"enabled"`
 	Version    string   `yaml:"version"`
 	K3sArgs    []string `yaml:"k3sArgs"`
-	ListenPort int      `yaml:"listenPort,omitempty"`
+	ListenPort int      `yaml:"port,omitempty"`
 }
 
 // Network is VM network configuration

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -44,6 +44,11 @@ kubernetes:
   # Default: traefik is disabled
   k3sArgs: [--disable=traefik]
 
+  # Kubernetes port to listen on
+  # A common port is 6443, though left unbound to ensure no port conflicts
+  # Default: pick random unbound port
+  listenPort: 0
+
 # Auto-activate on the Host for client access.
 # Setting to true does the following on startup
 #  - sets as active Docker context (for Docker runtime).

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -47,7 +47,7 @@ kubernetes:
   # Kubernetes port to listen on
   # A common port is 6443, though left unbound to ensure no port conflicts
   # Default: pick random unbound port
-  listenPort: 0
+  port: 0
 
 # Auto-activate on the Host for client access.
 # Setting to true does the following on startup

--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -40,11 +40,11 @@ func installK3s(host environment.HostActions,
 	log *logrus.Entry,
 	containerRuntime string,
 	k3sVersion string,
-	disable []string,
+	k3sArgs []string,
 ) {
 	installK3sBinary(host, guest, a, k3sVersion)
 	installK3sCache(host, guest, a, log, containerRuntime, k3sVersion)
-	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, disable)
+	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, k3sArgs)
 }
 
 func installK3sBinary(

--- a/environment/container/kubernetes/k3s.go
+++ b/environment/container/kubernetes/k3s.go
@@ -41,10 +41,11 @@ func installK3s(host environment.HostActions,
 	containerRuntime string,
 	k3sVersion string,
 	k3sArgs []string,
+	k3sListenPort int,
 ) {
 	installK3sBinary(host, guest, a, k3sVersion)
 	installK3sCache(host, guest, a, log, containerRuntime, k3sVersion)
-	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, k3sArgs)
+	installK3sCluster(host, guest, a, containerRuntime, k3sVersion, k3sArgs, k3sListenPort)
 }
 
 func installK3sBinary(
@@ -141,6 +142,7 @@ func installK3sCluster(
 	containerRuntime string,
 	k3sVersion string,
 	k3sArgs []string,
+	k3sListenPort int,
 ) {
 	// install k3s last to ensure it is the last step
 	downloadPath := "/tmp/k3s-install.sh"
@@ -184,7 +186,7 @@ func installK3sCluster(
 	}
 
 	a.Add(func() error {
-		port, err := getPortNumber(guest)
+		port, err := getPortNumber(guest, k3sListenPort)
 		if err != nil {
 			return err
 		}
@@ -199,7 +201,7 @@ func installK3sCluster(
 
 // getPortNumber retrieves the previously set port number.
 // If missing, an available random port is set and return.
-func getPortNumber(guest environment.GuestActions) (int, error) {
+func getPortNumber(guest environment.GuestActions, k3sListenPort int) (int, error) {
 	// port previously set, reuse it
 	if port, err := strconv.Atoi(guest.Get(listenPortKey)); err == nil && port > 0 {
 		return port, nil
@@ -211,8 +213,15 @@ func getPortNumber(guest environment.GuestActions) (int, error) {
 		return 6443, nil
 	}
 
-	// new instance, assign random port
-	port := util.RandomAvailablePort()
+	var port int
+	if k3sListenPort > 0 {
+		// template configured port
+		port = k3sListenPort
+	} else {
+		// new instance, assign random port
+		port = util.RandomAvailablePort()
+	}
+
 	if err := guest.Set(listenPortKey, strconv.Itoa(port)); err != nil {
 		return 0, err
 	}

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -117,7 +117,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 			installK3sCache(c.host, c.guest, a, log, runtime, conf.Version)
 		}
 		// other settings may have changed e.g. ingress
-		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.K3sArgs)
+		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.K3sArgs, conf.ListenPort)
 	} else {
 		if c.isInstalled() {
 			a.Stagef("version changed to %s, downloading and installing", conf.Version)
@@ -128,7 +128,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 				a.Stage("installing")
 			}
 		}
-		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.K3sArgs)
+		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.K3sArgs, conf.ListenPort)
 	}
 
 	// this needs to happen on each startup

--- a/environment/container/kubernetes/kubernetes.go
+++ b/environment/container/kubernetes/kubernetes.go
@@ -117,7 +117,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 			installK3sCache(c.host, c.guest, a, log, runtime, conf.Version)
 		}
 		// other settings may have changed e.g. ingress
-		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.K3sArgs, conf.ListenPort)
+		installK3sCluster(c.host, c.guest, a, runtime, conf.Version, conf.K3sArgs, conf.Port)
 	} else {
 		if c.isInstalled() {
 			a.Stagef("version changed to %s, downloading and installing", conf.Version)
@@ -128,7 +128,7 @@ func (c *kubernetesRuntime) Provision(ctx context.Context) error {
 				a.Stage("installing")
 			}
 		}
-		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.K3sArgs, conf.ListenPort)
+		installK3s(c.host, c.guest, a, log, runtime, conf.Version, conf.K3sArgs, conf.Port)
 	}
 
 	// this needs to happen on each startup

--- a/environment/vm/lima/file.go
+++ b/environment/vm/lima/file.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	"github.com/abiosoft/colima/environment"
 )
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -16,16 +19,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678654296,
-        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
+        "lastModified": 1748026580,
+        "narHash": "sha256-rWtXrcIzU5wm/C8F9LWvUfBGu5U5E7cFzPYT1pHIJaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
+        "rev": "11cb3517b3af6af300dd6c055aeda73c9bf52c48",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -34,6 +37,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "Container runtimes on macOS (and Linux) with minimal setup";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  # Last revision with go_1_23
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/25.05";
 
   outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem
     (system:

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
 pkgs.mkShell {
   # nativeBuildInputs is usually what you want -- tools you need to run
   nativeBuildInputs = with pkgs.buildPackages; [
-    go_1_20
+    go_1_23
     git
     lima
     qemu

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ pkgs.mkShell {
   # nativeBuildInputs is usually what you want -- tools you need to run
   nativeBuildInputs = with pkgs.buildPackages; [
     go_1_23
+    gotools
     git
     lima
     qemu

--- a/util/fsutil/fs.go
+++ b/util/fsutil/fs.go
@@ -34,7 +34,8 @@ func (DefaultFS) Open(name string) (fs.File, error) { return os.Open(name) }
 func (DefaultFS) MkdirAll(path string, perm fs.FileMode) error { return os.MkdirAll(path, perm) }
 
 // FakeFS is a mock FS. The following can be done in a test before usage.
-//   osutil.FS = osutil.FakeFS
+//
+//	osutil.FS = osutil.FakeFS
 var FakeFS FileSystem = fakeFS{}
 
 type fakeFS struct{}


### PR DESCRIPTION
Resolves #467 

- upgrade nix infrastructure to support golang 1.23.x
- formatting
- exposing a way to customize the k3s listen port