### PR TITLE
docs: add direct url to project website

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Check [here](docs/CONTRIBUTE.md) for the instructions on contributing to the pro
 
 ## Help Wanted
 
-- Documentation and project website
+- Documentation and project [website](lima-vm.io)
 
 ## License
 


### PR DESCRIPTION
SEO seems also low as my search engine only return the Github repo and the only mention I can find of the URL is in [this discussion thread](https://github.com/abiosoft/colima/discussions/636), so adding the official project website to the README will make it easier to find, especially that the about section of the project does not have it listed (maybe the reviewer of this PR can also add that? 💡 🤔)
