### PR TITLE
docs: specify qemu-full for Arch instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -40,10 +40,8 @@ nix-shell -p colima
 
 Install dependencies
 ```
-# If you see issues with ssh, try `qemu-full` instead.
-sudo pacman -S qemu-base go docker
+sudo pacman -S qemu-full go docker
 ```
-
 Install Lima and Colima from Aur
 ```
 yay -S lima-bin colima-bin


### PR DESCRIPTION
Issue (https://github.com/abiosoft/colima/issues/1165)

Using `qemu-full` resolves the issue mentioned in the link above on my machine. I don't know the implications of choosing this library over the base, only that there are added features and a gui.

I'm using Arch 6.17.8 on my machine and am able to use Colima fine after this change.