### PR TITLE
incus: use RFC 5737 IPv4 network for the default network

### DIFF
--- a/environment/container/incus/config.yaml
+++ b/environment/container/incus/config.yaml
@@ -1,6 +1,6 @@
 networks:
   - config:
-      ipv4.address: 192.100.0.1/24
+      ipv4.address: 192.168.100.1/24
       ipv4.nat: "true"
       ipv6.address: auto
     description: ""


### PR DESCRIPTION
[RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737) establishes a few IP subnets reserved for documentation-use. Since in the comments for 3317db1 it was expressed that users should simply run `incus network edit incusbr0`, it seems appropriate that a documentation-use range be used as the default here, since the defaults then kind-of represent a sample config which should be changed later.

It's also not the end of the world if two applications clash in the RFC5737 range, since if that happens, the user should simply change one of the applications to a subnet of their choice. The RFC5737 probably will never be a system-default subnet that could cause bad behaviour if clashed with.

Fixes #1486.