### PR TITLE
ai: add docker model runner.

### DIFF
--- a/cmd/model.go
+++ b/cmd/model.go
@@ -1,35 +1,19 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"strings"
-	"time"
 
-	"github.com/abiosoft/colima/cli"
 	"github.com/abiosoft/colima/cmd/root"
-	"github.com/abiosoft/colima/config"
 	"github.com/abiosoft/colima/config/configmanager"
-	"github.com/abiosoft/colima/environment/container/docker"
-	"github.com/abiosoft/colima/environment/host"
-	"github.com/abiosoft/colima/environment/vm/lima"
-	"github.com/abiosoft/colima/environment/vm/lima/limaconfig"
-	"github.com/abiosoft/colima/store"
-	"github.com/abiosoft/colima/util"
+	"github.com/abiosoft/colima/model"
 	"github.com/abiosoft/colima/util/terminal"
-	"github.com/coreos/go-semver/semver"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// gpuSubcommands are ramalama subcommands that need GPU device passthrough.
-var gpuSubcommands = map[string]bool{
-	"run":        true,
-	"serve":      true,
-	"bench":      true,
-	"chat":       true,
-	"perplexity": true,
+// modelCmdArgs holds command-line flags for the model command.
+var modelCmdArgs struct {
+	Runner    string
+	ServePort int
 }
 
 // modelCmd represents the model command
@@ -39,289 +23,180 @@ var modelCmd = &cobra.Command{
 	Long: `Manage AI models inside the VM.
 This requires docker runtime and krunkit VM type for GPU access.
 
-All arguments are passed to the AI model runner.
-Specifying '--' will pass arguments to the underlying (ramalama) tool.
+Use --runner to select the model runner:
+  - docker: Docker Model Runner (default)
+  - ramalama: Ramalama
+
+All arguments are passed to the selected AI model runner.
+Specifying '--' will pass arguments to the underlying tool.
 
 Examples:
   colima model list
-  colima model pull tinyllama
-  colima model run tinyllama
-  colima model serve tinyllama
-  colima model serve -- --help
+  colima model pull ai/smollm2
+  colima model run ai/smollm2
+  colima model serve
+  colima model serve ai/smollm2 --port 8080
 
-Multiple registries are supported including HuggingFace.co (default) and
-Ollama.
-
-Examples:
-  colima model run hf://gemma3
-  colima model run ollama://gemma3
+Multiple registries are supported.
 `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return validateModelPrerequisites()
+		runner, err := getModelRunner()
+		if err != nil {
+			return err
+		}
+		return runner.ValidatePrerequisites(newApp())
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmd.Help()
 		}
 
-		a := newApp()
-
-		if err := ensureRamalamaProvisioned(); err != nil {
+		runner, err := getModelRunner()
+		if err != nil {
 			return err
 		}
 
-		ramalamaArgs := buildRamalamaArgs(args)
-		return a.SSH(ramalamaArgs...)
+		a := newApp()
+
+		if err := runner.EnsureProvisioned(); err != nil {
+			return err
+		}
+
+		runnerArgs, err := runner.BuildArgs(args)
+		if err != nil {
+			return err
+		}
+		return a.SSH(runnerArgs...)
 	},
 }
 
-// modelSetupCmd forces re-provisioning of ramalama in the VM.
+// modelSetupCmd reinstalls the model runner in the VM.
 var modelSetupCmd = &cobra.Command{
 	Use:     "setup",
 	Short:   "install or update AI model runner in the VM",
 	Long:    `Install or update AI model runner and its dependencies in the VM.`,
 	Aliases: []string{"update"},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return validateModelPrerequisites()
+		runner, err := getModelRunner()
+		if err != nil {
+			return err
+		}
+		return runner.ValidatePrerequisites(newApp())
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return setupOrUpdateRamalama()
+		runner, err := getModelRunner()
+		if err != nil {
+			return err
+		}
+
+		// Build header for alternate screen
+		var header string
+		separator := "────────────────────────────────────────"
+		if runner.Name() == model.RunnerDocker {
+			header = fmt.Sprintf("Colima - Docker Model Runner Setup\n%s", separator)
+		} else {
+			header = fmt.Sprintf("Colima - Ramalama Setup\n%s", separator)
+		}
+
+		// Run in alternate screen with header
+		return terminal.WithAltScreen(func() error {
+			return runner.Setup()
+		}, header)
+	},
+}
+
+// modelServeCmd serves a model API.
+var modelServeCmd = &cobra.Command{
+	Use:   "serve [model]",
+	Short: "serve a model API",
+	Long: `Serve a model API.
+
+This starts a model server providing:
+  - OpenAI-compatible API at http://localhost:<port>/v1
+  - Web UI for chat at http://localhost:<port>
+
+Press Ctrl-C to stop the server.
+`,
+	Args: cobra.MaximumNArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		runner, err := getModelRunner()
+		if err != nil {
+			return err
+		}
+		return runner.ValidatePrerequisites(newApp())
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		runner, err := getModelRunner()
+		if err != nil {
+			return err
+		}
+
+		// Determine the model to serve
+		var modelName string
+		if len(args) > 0 {
+			modelName = args[0]
+		} else if runner.Name() == model.RunnerDocker {
+			// For docker runner, get the first available model
+			firstModel, err := model.GetFirstModel()
+			if err != nil {
+				return err
+			}
+			if firstModel == "" {
+				return fmt.Errorf("no models available\nPull a model first: colima model pull ai/smollm2")
+			}
+			modelName = firstModel
+		} else {
+			return fmt.Errorf("model name is required for ramalama runner\nUsage: colima model serve <model>")
+		}
+
+		if err := runner.EnsureProvisioned(); err != nil {
+			return err
+		}
+
+		// Ensure the model is available (pull if necessary) - this happens outside alternate screen
+		normalizedModel, err := runner.EnsureModel(modelName)
+		if err != nil {
+			return err
+		}
+
+		// Build header for alternate screen
+		separator := "────────────────────────────────────────"
+		header := fmt.Sprintf("Colima - Model Server (Ctrl-C to stop)\nWeb UI & API at http://localhost:%d\n%s", modelCmdArgs.ServePort, separator)
+
+		// Run in alternate screen with header
+		return terminal.WithAltScreen(func() error {
+			return runner.Serve(normalizedModel, modelCmdArgs.ServePort)
+		}, header)
 	},
 }
 
 func init() {
 	root.Cmd().AddCommand(modelCmd)
 	modelCmd.AddCommand(modelSetupCmd)
+	modelCmd.AddCommand(modelServeCmd)
+
+	// Add --runner flag with default from config or ramalama
+	modelCmd.PersistentFlags().StringVar(&modelCmdArgs.Runner, "runner", "", "AI model runner (docker, ramalama)")
+
+	// Add --port flag for serve command
+	modelServeCmd.Flags().IntVar(&modelCmdArgs.ServePort, "port", 8080, "port for the web UI")
 }
 
-// validateModelPrerequisites checks that the VM is running with the correct
-// configuration for AI model support.
-func validateModelPrerequisites() error {
-	a := newApp()
+// getModelRunner returns the appropriate runner based on flag or config.
+func getModelRunner() (model.Runner, error) {
+	runnerType := modelCmdArgs.Runner
 
-	// VM must be running
-	if !a.Active() {
-		return fmt.Errorf("%s is not running", config.CurrentProfile().DisplayName)
-	}
-
-	// check runtime is docker
-	r, err := a.Runtime()
-	if err != nil {
-		return err
-	}
-	if r != docker.Name {
-		return fmt.Errorf("'colima model' requires docker runtime, current runtime is %s\n"+
-			"Start colima with: colima start --runtime docker --vm-type krunkit", r)
-	}
-
-	// check VM type is krunkit
-	conf, err := configmanager.LoadInstance()
-	if err != nil {
-		return fmt.Errorf("error loading instance config: %w", err)
-	}
-	if conf.VMType != limaconfig.Krunkit {
-		return fmt.Errorf("'colima model' requires krunkit VM type for GPU access, current VM type is %s\n"+
-			"Start colima with: colima start --runtime docker --vm-type krunkit", conf.VMType)
-	}
-
-	// check krunkit binary exists on host
-	if err := util.AssertKrunkit(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ensureRamalamaProvisioned checks if ramalama has been provisioned in the VM
-// and provisions it if not.
-func ensureRamalamaProvisioned() error {
-	s, _ := store.Load()
-	if s.RamalamaProvisioned {
-		return nil
-	}
-
-	if !cli.Prompt("AI model support requires initial setup (this may take a few minutes depending on internet connection speed). Continue") {
-		return fmt.Errorf("setup cancelled")
-	}
-
-	return provisionRamalama()
-}
-
-const ramalamaReleasesURL = "https://api.github.com/repos/containers/ramalama/releases/latest"
-
-// setupOrUpdateRamalama handles both fresh installs and updates with version checking.
-func setupOrUpdateRamalama() error {
-	s, _ := store.Load()
-
-	// Fresh install - no version check needed
-	if !s.RamalamaProvisioned {
-		if err := provisionRamalama(); err != nil {
-			return err
+	// If not specified via flag, check instance config
+	if runnerType == "" {
+		if conf, err := configmanager.LoadInstance(); err == nil && conf.ModelRunner != "" {
+			runnerType = conf.ModelRunner
 		}
-		// Print installed version
-		if version := getRamalamaVersion(); version != "" {
-			fmt.Println("AI model runner")
-			fmt.Printf("version: %s", version)
-			fmt.Println()
-		}
-		return nil
 	}
 
-	// Update - check versions first
-	currentVersion := getRamalamaVersion()
-	if currentVersion == "" {
-		// Can't determine current version, proceed with update
-		log.Debug("could not determine current ramalama version, proceeding with update")
-		return provisionRamalama()
+	// Default to docker
+	if runnerType == "" {
+		runnerType = string(model.RunnerDocker)
 	}
 
-	latestVersion, err := getLatestRamalamaVersion()
-	if err != nil {
-		log.Debugf("could not fetch latest ramalama version: %v", err)
-		return fmt.Errorf("could not check for updates: %w", err)
-	}
-
-	// Compare versions
-	current, err := semver.NewVersion(currentVersion)
-	if err != nil {
-		log.Debugf("could not parse current version %q: %v", currentVersion, err)
-		return provisionRamalama()
-	}
-
-	latest, err := semver.NewVersion(latestVersion)
-	if err != nil {
-		log.Debugf("could not parse latest version %q: %v", latestVersion, err)
-		return provisionRamalama()
-	}
-
-	// Show version info
-	fmt.Println("AI model runner")
-	fmt.Printf("current: %s", currentVersion)
-	fmt.Println()
-	fmt.Printf("latest:  %s", latestVersion)
-	fmt.Println()
-
-	if current.Compare(*latest) >= 0 {
-		fmt.Println()
-		fmt.Println("Already up to date")
-		return nil
-	}
-
-	if err := provisionRamalama(); err != nil {
-		return err
-	}
-
-	// Print new version
-	if newVersion := getRamalamaVersion(); newVersion != "" {
-		fmt.Printf("updated: %s", newVersion)
-		fmt.Println()
-	}
-	return nil
-}
-
-// getRamalamaVersion returns the currently installed ramalama version in the VM.
-// Returns empty string if ramalama is not installed or version cannot be determined.
-func getRamalamaVersion() string {
-	guest := lima.New(host.New())
-	output, err := guest.RunOutput("sh", "-c", `export PATH="$HOME/.local/bin:$PATH"; ramalama version 2>/dev/null`)
-	if err != nil {
-		return ""
-	}
-	// Output format: "ramalama version 0.17.1"
-	output = strings.TrimSpace(output)
-	if version, ok := strings.CutPrefix(output, "ramalama version "); ok {
-		return version
-	}
-	return ""
-}
-
-// getLatestRamalamaVersion fetches the latest release version from GitHub.
-func getLatestRamalamaVersion() (string, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(ramalamaReleasesURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch releases: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	var release struct {
-		TagName string `json:"tag_name"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	// Tag might be "v0.17.1" or "0.17.1"
-	version := strings.TrimPrefix(release.TagName, "v")
-	return version, nil
-}
-
-// provisionRamalama installs ramalama and its dependencies in the VM.
-func provisionRamalama() error {
-	guest := lima.New(host.New())
-
-	script := `set -e
-export PATH="$HOME/.local/bin:$PATH"
-
-# install ramalama
-curl -fsSL https://ramalama.ai/install.sh | bash
-
-# pull ramalama container images
-docker pull quay.io/ramalama/ramalama
-docker pull quay.io/ramalama/ramalama-rag
-
-# fix ownership of persistent data dir and symlink to expected location
-sudo chown -R $(id -u):$(id -g) /var/lib/ramalama
-mkdir -p "$HOME/.local/share"
-ln -sfn /var/lib/ramalama "$HOME/.local/share/ramalama"
-`
-
-	log.Println("installing AI model runner...")
-
-	if err := terminal.WithAltScreen(func() error {
-		return guest.RunInteractive("sh", "-c", script)
-	},
-		"",
-		"  Colima - AI Model Runner Setup",
-		"  ===============================",
-		"",
-		"  Installing AI model runner.",
-		"  This may take several minutes depending on your internet connection speed.",
-	); err != nil {
-		return fmt.Errorf("error setting up AI model runner: %w", err)
-	}
-
-	log.Println("AI model runner installed")
-
-	// mark as provisioned
-	if err := store.Set(func(s *store.Store) {
-		s.RamalamaProvisioned = true
-	}); err != nil {
-		return fmt.Errorf("error saving provisioning state: %w", err)
-	}
-
-	return nil
-}
-
-// buildRamalamaArgs constructs the full argument list for running ramalama
-// in the VM, including environment variables and device passthrough.
-// Uses sh -c with "$@" pattern so $HOME and $PATH are properly expanded.
-func buildRamalamaArgs(args []string) []string {
-	shellCmd := `export RAMALAMA_CONTAINER_ENGINE=docker PATH="$HOME/.local/bin:$PATH"; exec ramalama "$@"`
-
-	ramalamaArgs := []string{"sh", "-c", shellCmd, "--"}
-
-	// for GPU subcommands, inject --device=/dev/dri after the subcommand name
-	if len(args) > 0 && gpuSubcommands[args[0]] {
-		ramalamaArgs = append(ramalamaArgs, args[0], "--device=/dev/dri")
-		ramalamaArgs = append(ramalamaArgs, args[1:]...)
-	} else {
-		ramalamaArgs = append(ramalamaArgs, args...)
-	}
-
-	return ramalamaArgs
+	return model.GetRunner(model.RunnerType(runnerType))
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -207,6 +207,7 @@ func init() {
 			startCmd.Flags().StringVarP(&startCmdArgs.VMType, "vm-type", "t", defaultVMType, "virtual machine type ("+types+")")
 			if util.MacOS13OrNewerOnArm() {
 				startCmd.Flags().BoolVar(&startCmdArgs.VZRosetta, "vz-rosetta", false, "enable Rosetta for amd64 emulation")
+				startCmd.Flags().StringVar(&startCmdArgs.ModelRunner, "model-runner", "docker", "AI model runner (docker, ramalama)")
 				binfmtDesc += " (no-op if Rosetta is enabled)"
 			}
 		}
@@ -506,6 +507,11 @@ func prepareConfig(cmd *cobra.Command) {
 	}
 	if !cmd.Flag("runtime").Changed {
 		startCmdArgs.Runtime = current.Runtime
+	}
+	if util.MacOS13OrNewerOnArm() {
+		if !cmd.Flag("model-runner").Changed {
+			startCmdArgs.ModelRunner = current.ModelRunner
+		}
 	}
 	if !cmd.Flag("cpus").Changed {
 		startCmdArgs.CPU = current.CPU

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,6 +6,7 @@ import (
 	"github.com/abiosoft/colima/app"
 	"github.com/abiosoft/colima/cmd/root"
 	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/model"
 	"github.com/abiosoft/colima/store"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +28,7 @@ var versionCmd = &cobra.Command{
 			// Show AI model runner version if provisioned
 			s, _ := store.Load()
 			if s.RamalamaProvisioned {
-				if modelVersion := getRamalamaVersion(); modelVersion != "" {
+				if modelVersion := model.GetRamalamaVersion(); modelVersion != "" {
 					fmt.Println()
 					fmt.Println("AI model runner")
 					fmt.Println("version:", modelVersion)

--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,9 @@ type Config struct {
 	Runtime         string `yaml:"runtime,omitempty"`
 	ActivateRuntime *bool  `yaml:"autoActivate,omitempty"`
 
+	// ModelRunner is the AI model runner (docker, ramalama).
+	ModelRunner string `yaml:"modelRunner,omitempty"`
+
 	// Kubernetes configuration
 	Kubernetes Kubernetes `yaml:"kubernetes,omitempty"`
 

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -24,6 +24,14 @@ arch: host
 # Default: docker
 runtime: docker
 
+# AI model runner (docker, ramalama).
+# Both require krunkit VM type for GPU access.
+# docker: Uses Docker Model Runner.
+# ramalama: Uses Ramalama.
+#
+# Default: docker
+modelRunner: docker
+
 # Set custom hostname for the virtual machine.
 # Default: colima
 #          colima-profile_name for other profiles

--- a/model/docker.go
+++ b/model/docker.go
@@ -1,0 +1,335 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/abiosoft/colima/environment"
+	"github.com/abiosoft/colima/environment/host"
+	"github.com/abiosoft/colima/environment/vm/lima"
+	"github.com/abiosoft/colima/util/terminal"
+	log "github.com/sirupsen/logrus"
+)
+
+// DockerModelInfo represents the output of docker model inspect.
+type DockerModelInfo struct {
+	ID     string   `json:"id"`
+	Tags   []string `json:"tags"`
+	Config struct {
+		Format       string `json:"format"`
+		Quantization string `json:"quantization"`
+		Parameters   string `json:"parameters"`
+		Architecture string `json:"architecture"`
+		Size         string `json:"size"`
+	} `json:"config"`
+}
+
+// Hash returns the model's hash (without the "sha256:" prefix).
+func (m *DockerModelInfo) Hash() string {
+	if hash, ok := strings.CutPrefix(m.ID, "sha256:"); ok {
+		return hash
+	}
+	return ""
+}
+
+// ociManifest represents the OCI manifest structure for Docker models.
+type ociManifest struct {
+	Layers []struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+	} `json:"layers"`
+}
+
+// findGGUFPath finds the GGUF file path for a model inside the docker-model-runner container.
+// It handles both Docker registry models (bundle path) and HuggingFace models (blob path via manifest).
+// For models without a bundle, it creates the bundle structure by hard-linking the blob.
+func findGGUFPath(guest environment.VM, modelHash string) (string, error) {
+	// Standard bundle path used by Docker Model Runner for all models
+	bundlePath := fmt.Sprintf("/models/bundles/sha256/%s/model/model.gguf", modelHash)
+
+	// Check if bundle already exists
+	if err := guest.RunQuiet("docker", "exec", "docker-model-runner", "test", "-f", bundlePath); err == nil {
+		return bundlePath, nil
+	}
+
+	// Bundle doesn't exist - read manifest to find the GGUF blob and create the bundle
+	manifestPath := fmt.Sprintf("/models/manifests/sha256/%s", modelHash)
+	output, err := guest.RunOutput("docker", "exec", "docker-model-runner", "cat", manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read model manifest: %w", err)
+	}
+
+	var manifest ociManifest
+	if err := json.Unmarshal([]byte(output), &manifest); err != nil {
+		return "", fmt.Errorf("failed to parse model manifest: %w", err)
+	}
+
+	// Find the GGUF layer (mediaType contains "gguf")
+	var blobPath string
+	for _, layer := range manifest.Layers {
+		if strings.Contains(layer.MediaType, "gguf") {
+			if blobHash, ok := strings.CutPrefix(layer.Digest, "sha256:"); ok {
+				blobPath = fmt.Sprintf("/models/blobs/sha256/%s", blobHash)
+				break
+			}
+		}
+	}
+
+	if blobPath == "" {
+		return "", fmt.Errorf("no GGUF layer found in model manifest")
+	}
+
+	// Create bundle directory and hard-link the blob (same approach as Docker Model Runner)
+	bundleDir := fmt.Sprintf("/models/bundles/sha256/%s/model", modelHash)
+	if err := guest.RunQuiet("docker", "exec", "docker-model-runner", "mkdir", "-p", bundleDir); err != nil {
+		return "", fmt.Errorf("failed to create bundle directory: %w", err)
+	}
+
+	if err := guest.RunQuiet("docker", "exec", "docker-model-runner", "ln", blobPath, bundlePath); err != nil {
+		return "", fmt.Errorf("failed to link model file: %w", err)
+	}
+
+	return bundlePath, nil
+}
+
+// InspectDockerModel returns information about a Docker model.
+func InspectDockerModel(modelName string) (*DockerModelInfo, error) {
+	guest := lima.New(host.New())
+	output, err := guest.RunOutput("docker", "model", "inspect", modelName)
+	if err != nil {
+		return nil, fmt.Errorf("error inspecting model %q: %w", modelName, err)
+	}
+
+	var info DockerModelInfo
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &info); err != nil {
+		return nil, fmt.Errorf("error parsing model info: %w", err)
+	}
+
+	return &info, nil
+}
+
+// SetupOrUpdateDocker reinstalls Docker Model Runner in the VM.
+func SetupOrUpdateDocker() error {
+	guest := lima.New(host.New())
+
+	log.Println("reinstalling Docker Model Runner...")
+
+	if err := guest.RunInteractive("docker", "model", "reinstall-runner"); err != nil {
+		return fmt.Errorf("error reinstalling Docker Model Runner: %w", err)
+	}
+
+	log.Println("Docker Model Runner reinstalled")
+
+	// Print installed version
+	if version := GetDockerModelVersion(); version != "" {
+		fmt.Println("Docker Model Runner")
+		fmt.Printf("version: %s", version)
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// GetDockerModelVersion returns the Docker Model Runner version in the VM.
+// Returns empty string if version cannot be determined.
+func GetDockerModelVersion() string {
+	guest := lima.New(host.New())
+	output, err := guest.RunOutput("docker", "model", "version")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(output)
+}
+
+// EnsureDockerModel ensures a Docker model is available, pulling if necessary.
+// Returns the normalized model name (resolving aliases like hf.co → huggingface.co).
+func EnsureDockerModel(modelName string) (string, error) {
+	guest := lima.New(host.New())
+
+	// Try to inspect the model first
+	modelInfo, err := InspectDockerModel(modelName)
+	if err != nil {
+		// Model not found locally, try to pull it
+		if pullErr := guest.RunInteractive("docker", "model", "pull", modelName); pullErr != nil {
+			return "", fmt.Errorf("failed to pull model %q: %w", modelName, pullErr)
+		}
+		// Retry inspect after pull
+		modelInfo, err = InspectDockerModel(modelName)
+		if err != nil {
+			return "", fmt.Errorf("failed to inspect model %q after pull: %w", modelName, err)
+		}
+	}
+
+	// Return the first tag as the normalized name (e.g., "docker.io/ai/smollm2:latest")
+	if len(modelInfo.Tags) > 0 {
+		return modelInfo.Tags[0], nil
+	}
+	return modelName, nil
+}
+
+// DockerModelServeConfig holds configuration for serving a Docker model.
+type DockerModelServeConfig struct {
+	ModelName string // Model name (e.g., "smollm2")
+	Port      int    // Host port to expose the model on
+	Threads   int    // Number of CPU threads (default: 2)
+	GPULayers int    // Number of GPU layers (default: 999 = all)
+}
+
+// ServeDockerModel serves a Docker model with llama-server.
+// It runs llama-server interactively (with visible output) and uses socat to forward the port.
+// The function blocks until interrupted (Ctrl-C) or llama-server exits.
+// Note: Call EnsureDockerModel first to ensure the model is available.
+func ServeDockerModel(cfg DockerModelServeConfig) error {
+	guest := lima.New(host.New())
+
+	// Set defaults
+	if cfg.Threads <= 0 {
+		cfg.Threads = 2
+	}
+	if cfg.GPULayers <= 0 {
+		cfg.GPULayers = 999
+	}
+
+	// Get the model info (model should already be available via EnsureDockerModel)
+	modelInfo, err := InspectDockerModel(cfg.ModelName)
+	if err != nil {
+		return fmt.Errorf("failed to inspect model %q: %w", cfg.ModelName, err)
+	}
+
+	// Check model format - only GGUF models are supported
+	if modelInfo.Config.Format != "gguf" {
+		return fmt.Errorf("model %q has format %q, only GGUF models are supported\n"+
+			"Try a GGUF version of this model (e.g., from TheBloke on HuggingFace)",
+			cfg.ModelName, modelInfo.Config.Format)
+	}
+
+	modelHash := modelInfo.Hash()
+	if modelHash == "" {
+		return fmt.Errorf("could not determine hash for model %q", cfg.ModelName)
+	}
+
+	// Ensure docker-model-runner container is running (needed to find GGUF path)
+	if err := ensureDockerModelRunner(guest); err != nil {
+		return err
+	}
+
+	// Find the GGUF file path (handles both Docker registry and HuggingFace models)
+	ggufPath, err := findGGUFPath(guest, modelHash)
+	if err != nil {
+		return fmt.Errorf("could not find GGUF file for model %q: %w", cfg.ModelName, err)
+	}
+
+	// Get container IP
+	containerIP, err := getDockerModelRunnerIP(guest)
+	if err != nil {
+		return err
+	}
+
+	// Kill any existing socat on this port
+	stopSocat(guest, cfg.Port)
+
+	// Start socat in background to forward localhost:port → container_ip:port
+	if err := startSocat(guest, cfg.Port, containerIP); err != nil {
+		return fmt.Errorf("failed to start port forwarder: %w", err)
+	}
+
+	// Run llama-server interactively (blocking, with visible output)
+	// Ctrl-C will be received by the interactive process directly
+	// Use -it for TTY, -i for non-TTY (e.g., piped or CI environments)
+	execFlag := "-i"
+	if terminal.IsTerminal() {
+		execFlag = "-it"
+	}
+
+	err = guest.RunInteractive("docker", "exec", execFlag, "docker-model-runner",
+		"/app/bin/com.docker.llama-server",
+		"-ngl", fmt.Sprintf("%d", cfg.GPULayers),
+		"--metrics",
+		"--threads", fmt.Sprintf("%d", cfg.Threads),
+		"--model", ggufPath,
+		"--alias", cfg.ModelName,
+		"--host", "0.0.0.0",
+		"--port", fmt.Sprintf("%d", cfg.Port),
+		"--jinja",
+	)
+
+	// Cleanup socat on exit (whether normal exit or Ctrl-C)
+	stopSocat(guest, cfg.Port)
+
+	return err
+}
+
+// ensureDockerModelRunner ensures the docker-model-runner container is running.
+// Attempts to start it up to 3 times if not found.
+func ensureDockerModelRunner(guest environment.VM) error {
+	for attempt := 1; attempt <= 3; attempt++ {
+		// Check if container exists
+		if err := guest.RunQuiet("docker", "inspect", "docker-model-runner"); err == nil {
+			return nil
+		}
+
+		log.Infof("docker-model-runner not found, starting it (attempt %d/3)...", attempt)
+		_ = guest.Run("docker", "model", "start-runner")
+		time.Sleep(2 * time.Second)
+	}
+
+	return fmt.Errorf("could not start docker-model-runner after 3 attempts")
+}
+
+// getDockerModelRunnerIP returns the IP address of the docker-model-runner container.
+func getDockerModelRunnerIP(guest environment.VM) (string, error) {
+	output, err := guest.RunOutput("docker", "inspect", "docker-model-runner",
+		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
+	if err != nil {
+		return "", fmt.Errorf("failed to get container IP: %w", err)
+	}
+
+	ip := strings.TrimSpace(output)
+	if ip == "" {
+		return "", fmt.Errorf("container IP is empty")
+	}
+
+	return ip, nil
+}
+
+// startSocat starts socat in the background to forward a port to the container.
+func startSocat(guest environment.VM, port int, containerIP string) error {
+	cmd := fmt.Sprintf("nohup socat TCP-LISTEN:%d,fork,reuseaddr TCP:%s:%d > /dev/null 2>&1 &",
+		port, containerIP, port)
+	return guest.Run("sh", "-c", cmd)
+}
+
+// stopSocat stops the socat process for a given port.
+func stopSocat(guest environment.VM, port int) {
+	cmd := fmt.Sprintf("pkill -f 'socat.*TCP-LISTEN:%d' 2>/dev/null || true", port)
+	_ = guest.Run("sh", "-c", cmd)
+}
+
+// StopDockerModelServe stops a Docker model serve instance.
+func StopDockerModelServe(port int) error {
+	guest := lima.New(host.New())
+
+	// Stop the socat proxy on the VM
+	stopCmd := fmt.Sprintf("pkill -f 'socat.*TCP-LISTEN:%d' 2>/dev/null || true", port)
+	if err := guest.Run("sh", "-c", stopCmd); err != nil {
+		log.Debugf("error stopping socat: %v", err)
+	}
+
+	// Note: llama-server processes inside docker-model-runner are harder to clean up
+	// since they run in the same container. For now, we just stop the socat proxy.
+	// The llama-server process will remain running but be inaccessible.
+
+	return nil
+}
+
+// IsDockerModelServeRunning checks if a serve instance is running on the given port.
+func IsDockerModelServeRunning(port int) bool {
+	guest := lima.New(host.New())
+
+	// Check if socat is running for this port
+	checkCmd := fmt.Sprintf("pgrep -f 'socat.*TCP-LISTEN:%d' > /dev/null 2>&1", port)
+	err := guest.Run("sh", "-c", checkCmd)
+	return err == nil
+}

--- a/model/ramalama.go
+++ b/model/ramalama.go
@@ -1,0 +1,248 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/abiosoft/colima/environment/host"
+	"github.com/abiosoft/colima/environment/vm/lima"
+	"github.com/abiosoft/colima/store"
+	"github.com/coreos/go-semver/semver"
+	log "github.com/sirupsen/logrus"
+)
+
+const ramalamaReleasesURL = "https://api.github.com/repos/containers/ramalama/releases/latest"
+
+// SetupOrUpdateRamalama handles both fresh installs and updates with version checking.
+func SetupOrUpdateRamalama() error {
+	s, _ := store.Load()
+
+	// Fresh install - no version check needed
+	if !s.RamalamaProvisioned {
+		if err := ProvisionRamalama(); err != nil {
+			return err
+		}
+		// Print installed version
+		if version := GetRamalamaVersion(); version != "" {
+			fmt.Println("AI model runner")
+			fmt.Printf("version: %s", version)
+			fmt.Println()
+		}
+		return nil
+	}
+
+	// Update - check versions first
+	currentVersion := GetRamalamaVersion()
+	if currentVersion == "" {
+		// Can't determine current version, proceed with update
+		log.Debug("could not determine current ramalama version, proceeding with update")
+		return ProvisionRamalama()
+	}
+
+	latestVersion, err := getLatestRamalamaVersion()
+	if err != nil {
+		log.Debugf("could not fetch latest ramalama version: %v", err)
+		return fmt.Errorf("could not check for updates: %w", err)
+	}
+
+	// Compare versions
+	current, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		log.Debugf("could not parse current version %q: %v", currentVersion, err)
+		return ProvisionRamalama()
+	}
+
+	latest, err := semver.NewVersion(latestVersion)
+	if err != nil {
+		log.Debugf("could not parse latest version %q: %v", latestVersion, err)
+		return ProvisionRamalama()
+	}
+
+	// Show version info
+	fmt.Println("AI model runner")
+	fmt.Printf("current: %s", currentVersion)
+	fmt.Println()
+	fmt.Printf("latest:  %s", latestVersion)
+	fmt.Println()
+
+	if current.Compare(*latest) >= 0 {
+		fmt.Println()
+		fmt.Println("Already up to date")
+		return nil
+	}
+
+	if err := ProvisionRamalama(); err != nil {
+		return err
+	}
+
+	// Print new version
+	if newVersion := GetRamalamaVersion(); newVersion != "" {
+		fmt.Printf("updated: %s", newVersion)
+		fmt.Println()
+	}
+	return nil
+}
+
+// GetRamalamaVersion returns the currently installed ramalama version in the VM.
+// Returns empty string if ramalama is not installed or version cannot be determined.
+func GetRamalamaVersion() string {
+	guest := lima.New(host.New())
+	output, err := guest.RunOutput("sh", "-c", `export PATH="$HOME/.local/bin:$PATH"; ramalama version 2>/dev/null`)
+	if err != nil {
+		return ""
+	}
+	// Output format: "ramalama version 0.17.1"
+	output = strings.TrimSpace(output)
+	if version, ok := strings.CutPrefix(output, "ramalama version "); ok {
+		return version
+	}
+	return ""
+}
+
+// getLatestRamalamaVersion fetches the latest release version from GitHub.
+func getLatestRamalamaVersion() (string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(ramalamaReleasesURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch releases: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Tag might be "v0.17.1" or "0.17.1"
+	version := strings.TrimPrefix(release.TagName, "v")
+	return version, nil
+}
+
+// ramalamaModel represents a model from ramalama ls --json output.
+type ramalamaModel struct {
+	Name     string `json:"name"`
+	Modified string `json:"modified"`
+	Size     int64  `json:"size"`
+}
+
+// listRamalamaModels returns all locally available ramalama models.
+func listRamalamaModels() ([]ramalamaModel, error) {
+	guest := lima.New(host.New())
+	output, err := guest.RunOutput("sh", "-c", `export PATH="$HOME/.local/bin:$PATH"; ramalama ls --json 2>/dev/null`)
+	if err != nil {
+		return nil, fmt.Errorf("error listing models: %w", err)
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" || output == "[]" {
+		return nil, nil
+	}
+
+	var models []ramalamaModel
+	if err := json.Unmarshal([]byte(output), &models); err != nil {
+		return nil, fmt.Errorf("error parsing model list: %w", err)
+	}
+
+	return models, nil
+}
+
+// ramalamaModelExists checks if a model exists locally in ramalama.
+func ramalamaModelExists(modelName string) bool {
+	models, err := listRamalamaModels()
+	if err != nil {
+		return false
+	}
+
+	// Normalize the input model name
+	normalizedInput := normalizeRamalamaModelName(modelName)
+
+	for _, m := range models {
+		// Model names in ramalama have format like "hf://TheBloke/..." or "ollama://library/..."
+		normalizedStored := normalizeRamalamaModelName(m.Name)
+		if normalizedInput == normalizedStored {
+			return true
+		}
+	}
+
+	return false
+}
+
+// normalizeRamalamaModelName normalizes a ramalama model name for comparison.
+func normalizeRamalamaModelName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+
+	// Normalize different URL formats to a common form
+	// "hf.co/..." -> "hf://..."
+	// "huggingface.co/..." -> "hf://..."
+	name = strings.ReplaceAll(name, "hf.co/", "hf://")
+	name = strings.ReplaceAll(name, "huggingface.co/", "hf://")
+
+	return name
+}
+
+// EnsureRamalamaModel ensures a ramalama model is available, pulling if necessary.
+func EnsureRamalamaModel(modelName string) error {
+	if ramalamaModelExists(modelName) {
+		return nil
+	}
+
+	// Model not found locally, pull it
+	guest := lima.New(host.New())
+	shellCmd := fmt.Sprintf(
+		`export RAMALAMA_CONTAINER_ENGINE=docker PATH="$HOME/.local/bin:$PATH"; ramalama pull %s`,
+		modelName,
+	)
+
+	if err := guest.RunInteractive("sh", "-c", shellCmd); err != nil {
+		return fmt.Errorf("failed to pull model %q: %w", modelName, err)
+	}
+
+	return nil
+}
+
+// ProvisionRamalama installs ramalama and its dependencies in the VM.
+func ProvisionRamalama() error {
+	guest := lima.New(host.New())
+
+	script := `set -e
+export PATH="$HOME/.local/bin:$PATH"
+
+# install ramalama
+curl -fsSL https://ramalama.ai/install.sh | bash
+
+# pull ramalama container images
+docker pull quay.io/ramalama/ramalama
+docker pull quay.io/ramalama/ramalama-rag
+
+# fix ownership of persistent data dir and symlink to expected location
+sudo chown -R $(id -u):$(id -g) /var/lib/ramalama
+mkdir -p "$HOME/.local/share"
+ln -sfn /var/lib/ramalama "$HOME/.local/share/ramalama"
+`
+
+	log.Println("installing AI model runner...")
+
+	if err := guest.RunInteractive("sh", "-c", script); err != nil {
+		return fmt.Errorf("error setting up AI model runner: %w", err)
+	}
+
+	log.Println("AI model runner installed")
+
+	// mark as provisioned
+	if err := store.Set(func(s *store.Store) {
+		s.RamalamaProvisioned = true
+	}); err != nil {
+		return fmt.Errorf("error saving provisioning state: %w", err)
+	}
+
+	return nil
+}

--- a/model/runner.go
+++ b/model/runner.go
@@ -1,0 +1,338 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/abiosoft/colima/app"
+	"github.com/abiosoft/colima/cli"
+	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/config/configmanager"
+	"github.com/abiosoft/colima/environment/container/docker"
+	"github.com/abiosoft/colima/environment/host"
+	"github.com/abiosoft/colima/environment/vm/lima"
+	"github.com/abiosoft/colima/environment/vm/lima/limaconfig"
+	"github.com/abiosoft/colima/store"
+	"github.com/abiosoft/colima/util"
+)
+
+// RunnerType represents the type of AI model runner.
+type RunnerType string
+
+const (
+	RunnerDocker   RunnerType = "docker"
+	RunnerRamalama RunnerType = "ramalama"
+)
+
+// Runner defines the interface for AI model runners.
+type Runner interface {
+	// Name returns the runner type name.
+	Name() RunnerType
+	// ValidatePrerequisites checks runner-specific requirements.
+	ValidatePrerequisites(a app.App) error
+	// EnsureProvisioned ensures the runner is set up (no-op for docker).
+	EnsureProvisioned() error
+	// BuildArgs constructs the command arguments for the runner.
+	// Returns an error if the command is not supported.
+	BuildArgs(args []string) ([]string, error)
+	// EnsureModel ensures a model is available (pulls if necessary).
+	// Returns the normalized model name.
+	EnsureModel(model string) (string, error)
+	// Serve starts serving a model on the given port.
+	// This is a blocking call that runs until interrupted.
+	// The model should already be available (call EnsureModel first).
+	Serve(model string, port int) error
+	// Setup installs or updates the runner.
+	Setup() error
+}
+
+// GetRunner returns the appropriate Runner based on type.
+func GetRunner(runnerType RunnerType) (Runner, error) {
+	switch runnerType {
+	case RunnerDocker:
+		return &dockerRunner{}, nil
+	case RunnerRamalama:
+		return &ramalamaRunner{}, nil
+	default:
+		return nil, fmt.Errorf("unknown runner type: %s (valid options: docker, ramalama)", runnerType)
+	}
+}
+
+// validateCommonPrerequisites checks prerequisites common to all runners.
+func validateCommonPrerequisites(a app.App) error {
+	// VM must be running
+	if !a.Active() {
+		return fmt.Errorf("%s is not running", config.CurrentProfile().DisplayName)
+	}
+
+	// check runtime is docker
+	r, err := a.Runtime()
+	if err != nil {
+		return err
+	}
+	if r != docker.Name {
+		return fmt.Errorf("'colima model' requires docker runtime, current runtime is %s\n"+
+			"Start colima with: colima start --runtime docker --vm-type krunkit", r)
+	}
+
+	// check VM type is krunkit (required for GPU access)
+	conf, err := configmanager.LoadInstance()
+	if err != nil {
+		return fmt.Errorf("error loading instance config: %w", err)
+	}
+	if conf.VMType != limaconfig.Krunkit {
+		return fmt.Errorf("'colima model' requires krunkit VM type for GPU access, current VM type is %s\n"+
+			"Start colima with: colima start --runtime docker --vm-type krunkit", conf.VMType)
+	}
+
+	// check krunkit binary exists on host
+	if err := util.AssertKrunkit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// dockerRunner implements Runner for Docker Model Runner.
+type dockerRunner struct{}
+
+func (d *dockerRunner) Name() RunnerType {
+	return RunnerDocker
+}
+
+func (d *dockerRunner) ValidatePrerequisites(a app.App) error {
+	return validateCommonPrerequisites(a)
+}
+
+func (d *dockerRunner) EnsureProvisioned() error {
+	// Docker Model Runner requires no provisioning
+	return nil
+}
+
+func (d *dockerRunner) BuildArgs(args []string) ([]string, error) {
+	// docker model <subcommand> [args...]
+	return append([]string{"docker", "model"}, args...), nil
+}
+
+// EnsureModel ensures a Docker model is available, pulling if necessary.
+// Returns the normalized model name (resolving aliases like hf.co → huggingface.co).
+func (d *dockerRunner) EnsureModel(modelName string) (string, error) {
+	return EnsureDockerModel(modelName)
+}
+
+// Serve starts serving a Docker model using llama-server.
+func (d *dockerRunner) Serve(modelName string, port int) error {
+	return ServeDockerModel(DockerModelServeConfig{
+		ModelName: modelName,
+		Port:      port,
+	})
+}
+
+// dockerModel represents a model from docker model list --json output.
+type dockerModel struct {
+	ID   string   `json:"id"`
+	Tags []string `json:"tags"`
+}
+
+// GetFirstModel returns the first available model from docker model list.
+// Returns empty string if no models are available.
+func GetFirstModel() (string, error) {
+	models, err := listDockerModels()
+	if err != nil {
+		return "", err
+	}
+	if len(models) == 0 {
+		return "", nil
+	}
+	// Return the first tag of the first model
+	if len(models[0].Tags) > 0 {
+		return models[0].Tags[0], nil
+	}
+	return "", nil
+}
+
+// listDockerModels returns all available models from docker model list.
+func listDockerModels() ([]dockerModel, error) {
+	guest := lima.New(host.New())
+	output, err := guest.RunOutput("docker", "model", "list", "--json")
+	if err != nil {
+		return nil, fmt.Errorf("error listing models: %w", err)
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" || output == "[]" {
+		return nil, nil
+	}
+
+	var models []dockerModel
+	if err := json.Unmarshal([]byte(output), &models); err != nil {
+		return nil, fmt.Errorf("error parsing model list: %w", err)
+	}
+
+	return models, nil
+}
+
+// ResolveModelName resolves a short model name to its full tag.
+// Supports flexible matching:
+//   - "smollm2" resolves to "docker.io/ai/smollm2:latest"
+//   - "ai/smollm2" resolves to "docker.io/ai/smollm2:latest"
+//   - "hf.co/..." resolves to "huggingface.co/..."
+//
+// Returns the original name if no match is found (for new models to be pulled).
+func ResolveModelName(name string) (string, error) {
+	models, err := listDockerModels()
+	if err != nil {
+		return name, err
+	}
+
+	for _, m := range models {
+		for _, tag := range m.Tags {
+			if matchesModel(name, tag) {
+				return tag, nil
+			}
+		}
+	}
+	// Return original name if not found (will be pulled)
+	return name, nil
+}
+
+// matchesModel checks if a user-provided name matches a full model tag.
+func matchesModel(name, tag string) bool {
+	// Normalize both for comparison
+	normName := normalizeModelName(name)
+	normTag := normalizeModelName(tag)
+
+	// Exact match after normalization
+	if normName == normTag {
+		return true
+	}
+
+	// Check if name is a suffix of tag (e.g., "smollm2" matches "ai/smollm2")
+	// Strip the tag version suffix for matching
+	tagParts := strings.Split(normTag, ":")
+	tagWithoutVersion := tagParts[0]
+	tagVersion := ""
+	if len(tagParts) > 1 {
+		tagVersion = tagParts[1]
+	}
+
+	nameParts := strings.Split(normName, ":")
+	nameWithoutVersion := nameParts[0]
+	nameHasVersion := len(nameParts) > 1
+
+	// If input has no version, only match :latest tags
+	if !nameHasVersion && tagVersion != "" && tagVersion != "latest" {
+		return false
+	}
+
+	// "smollm2" should match "ai/smollm2:latest"
+	if strings.HasSuffix(tagWithoutVersion, "/"+normName) {
+		return true
+	}
+
+	// "ai/smollm2" should match "docker.io/ai/smollm2" or just "ai/smollm2"
+	if strings.HasSuffix(tagWithoutVersion, "/"+nameWithoutVersion) {
+		return true
+	}
+
+	// Direct suffix match (handles cases like "tinyllama/tinyllama-1.1b-chat-v1.0")
+	if strings.HasSuffix(tagWithoutVersion, nameWithoutVersion) {
+		return true
+	}
+
+	return false
+}
+
+// normalizeModelName normalizes a model name for comparison.
+func normalizeModelName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+
+	// Normalize registry prefixes
+	name = strings.TrimPrefix(name, "docker.io/")
+	name = strings.ReplaceAll(name, "hf.co/", "huggingface.co/")
+
+	return name
+}
+
+func (d *dockerRunner) Setup() error {
+	return SetupOrUpdateDocker()
+}
+
+// gpuSubcommands are ramalama subcommands that need GPU device passthrough.
+var gpuSubcommands = map[string]bool{
+	"run":        true,
+	"serve":      true,
+	"bench":      true,
+	"chat":       true,
+	"perplexity": true,
+}
+
+// ramalamaRunner implements Runner for Ramalama.
+type ramalamaRunner struct{}
+
+func (r *ramalamaRunner) Name() RunnerType {
+	return RunnerRamalama
+}
+
+func (r *ramalamaRunner) ValidatePrerequisites(a app.App) error {
+	return validateCommonPrerequisites(a)
+}
+
+func (r *ramalamaRunner) EnsureProvisioned() error {
+	s, _ := store.Load()
+	if s.RamalamaProvisioned {
+		return nil
+	}
+
+	if !cli.Prompt("AI model support requires initial setup (this may take a few minutes depending on internet connection speed). Continue") {
+		return fmt.Errorf("setup cancelled")
+	}
+
+	return ProvisionRamalama()
+}
+
+func (r *ramalamaRunner) BuildArgs(args []string) ([]string, error) {
+	return r.buildRamalamaArgs(args), nil
+}
+
+// EnsureModel ensures a ramalama model is available, pulling if necessary.
+func (r *ramalamaRunner) EnsureModel(modelName string) (string, error) {
+	if err := EnsureRamalamaModel(modelName); err != nil {
+		return "", err
+	}
+	return modelName, nil
+}
+
+// Serve starts serving a model using ramalama.
+func (r *ramalamaRunner) Serve(modelName string, port int) error {
+	guest := lima.New(host.New())
+
+	// ramalama serve <model> with GPU support and custom port
+	shellCmd := fmt.Sprintf(
+		`export RAMALAMA_CONTAINER_ENGINE=docker PATH="$HOME/.local/bin:$PATH"; exec ramalama serve --device=/dev/dri -p %d %s`,
+		port, modelName,
+	)
+
+	return guest.RunInteractive("sh", "-c", shellCmd)
+}
+
+func (r *ramalamaRunner) buildRamalamaArgs(args []string) []string {
+	shellCmd := `export RAMALAMA_CONTAINER_ENGINE=docker PATH="$HOME/.local/bin:$PATH"; exec ramalama "$@"`
+
+	ramalamaArgs := []string{"sh", "-c", shellCmd, "--"}
+
+	// for GPU subcommands, inject --device=/dev/dri after the subcommand name
+	if len(args) > 0 && gpuSubcommands[args[0]] {
+		ramalamaArgs = append(ramalamaArgs, args[0], "--device=/dev/dri")
+		ramalamaArgs = append(ramalamaArgs, args[1:]...)
+	} else {
+		ramalamaArgs = append(ramalamaArgs, args...)
+	}
+
+	return ramalamaArgs
+}
+
+func (r *ramalamaRunner) Setup() error {
+	return SetupOrUpdateRamalama()
+}

--- a/model/runner_test.go
+++ b/model/runner_test.go
@@ -1,0 +1,261 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestNormalizeModelName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "lowercase conversion",
+			input:    "AI/SmollM2",
+			expected: "ai/smollm2",
+		},
+		{
+			name:     "trim whitespace",
+			input:    "  ai/smollm2  ",
+			expected: "ai/smollm2",
+		},
+		{
+			name:     "strip docker.io prefix",
+			input:    "docker.io/ai/smollm2",
+			expected: "ai/smollm2",
+		},
+		{
+			name:     "convert hf.co to huggingface.co",
+			input:    "hf.co/tinyllama/model",
+			expected: "huggingface.co/tinyllama/model",
+		},
+		{
+			name:     "already normalized",
+			input:    "ai/smollm2:latest",
+			expected: "ai/smollm2:latest",
+		},
+		{
+			name:     "huggingface.co unchanged",
+			input:    "huggingface.co/tinyllama/model:latest",
+			expected: "huggingface.co/tinyllama/model:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeModelName(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeModelName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchesModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		tag      string
+		expected bool
+	}{
+		// Exact matches
+		{
+			name:     "exact match with full tag",
+			input:    "docker.io/ai/smollm2:latest",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+		{
+			name:     "exact match after normalization",
+			input:    "ai/smollm2:latest",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+
+		// Short name matches
+		{
+			name:     "short name matches full tag",
+			input:    "smollm2",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+		{
+			name:     "short name with ai prefix",
+			input:    "ai/smollm2",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+		{
+			name:     "short name case insensitive",
+			input:    "SmollM2",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+
+		// Huggingface models
+		{
+			name:     "hf.co prefix matches huggingface.co",
+			input:    "hf.co/tinyllama/tinyllama-1.1b-chat-v1.0",
+			tag:      "huggingface.co/tinyllama/tinyllama-1.1b-chat-v1.0:latest",
+			expected: true,
+		},
+		{
+			name:     "huggingface short name",
+			input:    "tinyllama/tinyllama-1.1b-chat-v1.0",
+			tag:      "huggingface.co/tinyllama/tinyllama-1.1b-chat-v1.0:latest",
+			expected: true,
+		},
+		{
+			name:     "huggingface model name only",
+			input:    "tinyllama-1.1b-chat-v1.0",
+			tag:      "huggingface.co/tinyllama/tinyllama-1.1b-chat-v1.0:latest",
+			expected: true,
+		},
+
+		// Version tag handling
+		{
+			name:     "input without version matches tag with version",
+			input:    "ai/smollm2",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+		{
+			name:     "input with version matches tag with same version",
+			input:    "ai/smollm2:latest",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+		{
+			name:     "input with specific version matches tag with same version",
+			input:    "ai/smollm2:v1.0",
+			tag:      "docker.io/ai/smollm2:v1.0",
+			expected: true,
+		},
+		{
+			name:     "input without version does NOT match tag with specific version",
+			input:    "smollm2",
+			tag:      "docker.io/ai/smollm2:v1.0",
+			expected: false,
+		},
+		{
+			name:     "short name does NOT match tag with specific version",
+			input:    "gemma3",
+			tag:      "docker.io/ai/gemma3:4b-it-qat-q4_0",
+			expected: false,
+		},
+		{
+			name:     "input without version matches tag with latest",
+			input:    "smollm2",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: true,
+		},
+
+		// Non-matches
+		{
+			name:     "different model names",
+			input:    "smollm2",
+			tag:      "docker.io/ai/gemma3:latest",
+			expected: false,
+		},
+		{
+			name:     "partial name should not match",
+			input:    "smoll",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: false,
+		},
+		{
+			name:     "different registry",
+			input:    "ollama/smollm2",
+			tag:      "docker.io/ai/smollm2:latest",
+			expected: false,
+		},
+
+		// Edge cases
+		{
+			name:     "gemma3 short name",
+			input:    "gemma3",
+			tag:      "docker.io/ai/gemma3:latest",
+			expected: true,
+		},
+		{
+			name:     "ai/gemma3",
+			input:    "ai/gemma3",
+			tag:      "docker.io/ai/gemma3:latest",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := matchesModel(tt.input, tt.tag)
+			if result != tt.expected {
+				t.Errorf("matchesModel(%q, %q) = %v, want %v", tt.input, tt.tag, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveModelNameWithMockData(t *testing.T) {
+	// Test the resolution logic by testing matchesModel with various inputs
+	// against a set of mock tags that would come from docker model list
+
+	mockTags := []string{
+		"docker.io/ai/smollm2:latest",
+		"huggingface.co/tinyllama/tinyllama-1.1b-chat-v1.0:latest",
+		"docker.io/ai/gemma3:latest",
+	}
+
+	tests := []struct {
+		name        string
+		input       string
+		shouldMatch string // empty if no match expected
+	}{
+		{
+			name:        "smollm2 resolves to full tag",
+			input:       "smollm2",
+			shouldMatch: "docker.io/ai/smollm2:latest",
+		},
+		{
+			name:        "ai/smollm2 resolves to full tag",
+			input:       "ai/smollm2",
+			shouldMatch: "docker.io/ai/smollm2:latest",
+		},
+		{
+			name:        "gemma3 resolves to full tag",
+			input:       "gemma3",
+			shouldMatch: "docker.io/ai/gemma3:latest",
+		},
+		{
+			name:        "tinyllama model resolves",
+			input:       "tinyllama/tinyllama-1.1b-chat-v1.0",
+			shouldMatch: "huggingface.co/tinyllama/tinyllama-1.1b-chat-v1.0:latest",
+		},
+		{
+			name:        "hf.co prefix resolves",
+			input:       "hf.co/tinyllama/tinyllama-1.1b-chat-v1.0",
+			shouldMatch: "huggingface.co/tinyllama/tinyllama-1.1b-chat-v1.0:latest",
+		},
+		{
+			name:        "unknown model returns no match",
+			input:       "unknown-model",
+			shouldMatch: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var matched string
+			for _, tag := range mockTags {
+				if matchesModel(tt.input, tag) {
+					matched = tag
+					break
+				}
+			}
+
+			if matched != tt.shouldMatch {
+				t.Errorf("resolving %q: got %q, want %q", tt.input, matched, tt.shouldMatch)
+			}
+		})
+	}
+}

--- a/util/terminal/terminal.go
+++ b/util/terminal/terminal.go
@@ -11,6 +11,11 @@ import (
 
 var isTerminal = term.IsTerminal(int(os.Stdout.Fd()))
 
+// IsTerminal returns true if stdout is a terminal.
+func IsTerminal() bool {
+	return isTerminal
+}
+
 // ClearLine clears the previous line of the terminal
 func ClearLine() {
 	if !isTerminal {


### PR DESCRIPTION
### Generated by Copilot

This pull request introduces a major refactor to the AI model management commands, adding support for selecting between multiple model runners (Docker and Ramalama), streamlining runner setup and provisioning, and improving configuration handling. The changes also update command documentation and argument parsing, and unify model runner logic for easier extensibility.

Model runner selection and configuration:

* Added support for selecting the AI model runner (`docker`, `ramalama`) via the `--runner` flag, instance config (`modelRunner`), and default value. The runner is now used throughout model commands for provisioning, argument building, and serving. [[1]](diffhunk://#diff-da071e3daed57eecbf252a4a47a2727235fe6c01e78281b1d5faa6e60a53eaabL4-R16) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R64-R66) [[3]](diffhunk://#diff-a5c12a9d2cb0b374cc80b554d0c9667112763c4b0aad9ddb3a8ba6197f7e8a5dR27-R34)
* Updated the `start` command to accept a `--model-runner` flag, and propagate this value into instance configuration. [[1]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eR210) [[2]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eR511-R515)

Command logic and extensibility:

* Refactored the `model` command to use runner-specific methods for validation, provisioning, argument building, and serving, replacing hardcoded Ramalama logic with a unified runner interface.
* Added a new `model serve` command for serving models via a web UI and OpenAI-compatible API, using the selected runner.

Documentation and minor improvements:

* Improved command documentation and examples to reflect runner selection and usage, and updated help text for clarity.
* Updated version reporting to use the new runner interface for fetching Ramalama version. [[1]](diffhunk://#diff-7cb26babce207ed9c17e9dd3ead0b66d204da3cf4d11649412c197defbb3029cR9) [[2]](diffhunk://#diff-7cb26babce207ed9c17e9dd3ead0b66d204da3cf4d11649412c197defbb3029cL30-R31)