### PR TITLE
core: make cache directory configurable

### DIFF
--- a/config/files.go
+++ b/config/files.go
@@ -100,8 +100,11 @@ var (
 
 	cacheDir = requiredDir{
 		dir: func() (string, error) {
-			dir := os.Getenv("XDG_CACHE_HOME")
-			if dir != "" {
+			if dir := os.Getenv("COLIMA_CACHE_HOME"); dir != "" {
+				return dir, nil
+			}
+
+			if dir := os.Getenv("XDG_CACHE_HOME"); dir != "" {
 				return filepath.Join(dir, "colima"), nil
 			}
 			// else

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,6 +11,8 @@
     - [Editing the config](#editing-the-config)
     - [Setting the default config](#setting-the-default-config)
     - [Specifying the config editor](#specifying-the-config-editor)
+  - [How do I change where Colima files are stored?](#how-do-i-change-where-colima-files-are-stored)
+  - [How do I pass custom environment variables into the VM?](#how-do-i-pass-custom-environment-variables-into-the-vm)
   - [Docker](#docker)
     - [Can it run alongside Docker for Mac?](#can-it-run-alongside-docker-for-mac)
     - [Docker socket location](#docker-socket-location)
@@ -46,7 +48,6 @@
     - [Updating Colima](#updating-colima)
     - [Updating the container runtime](#updating-the-container-runtime)
     - [Accessing the Virtual Machine](#accessing-the-virtual-machine)
-    - [Environment variables](#environment-variables)
   - [Troubleshooting](#troubleshooting)
     - [Colima not starting](#colima-not-starting)
       - [Broken status](#broken-status)
@@ -143,6 +144,38 @@ Set the `$EDITOR` environment variable or use the `--editor` flag.
 ```sh
 colima start --edit --editor code # one-off config
 colima template --editor code # default config
+```
+
+## How do I change where Colima files are stored?
+
+Colima supports these environment variables, set on your host machine:
+
+| Variable | Description |
+|----------|-------------|
+| `COLIMA_HOME` | Colima configuration directory (default: `$HOME/.colima`) |
+| `COLIMA_CACHE_HOME` | Colima cache directory (default is host-specific, see [os.UserCacheDir()](https://pkg.go.dev/os#UserCacheDir)) |
+| `COLIMA_PROFILE` | Active profile name (default: `default`) |
+| `DOCKER_CONFIG` | Path to Docker client configuration directory (default: `~/.docker`) |
+
+## How do I pass custom environment variables into the VM?
+
+Pass environment variables into the VM at startup using the YAML configuration file:
+
+```yaml
+env:
+  MY_VAR: value
+```
+
+You can also use command-line flags:
+
+```bash session
+# On your host machine...
+$ colima start --env MY_VAR=value
+
+# Then, within the VM...
+$ colima ssh
+user@colima:~$ env | grep MY_VAR
+MY_VAR=value
 ```
 
 ## Docker
@@ -533,20 +566,6 @@ Run a single command without an interactive session:
 
 ```sh
 colima ssh -- uname -a
-```
-
-### Environment variables
-
-| Variable | Description |
-|----------|-------------|
-| `COLIMA_HOME` | Colima configuration directory (default: `$HOME/.colima`) |
-| `COLIMA_PROFILE` | Active profile name (default: `default`) |
-| `DOCKER_CONFIG` | Path to Docker client configuration directory (default: `~/.docker`) |
-
-Pass environment variables into the VM at startup:
-
-```sh
-colima start --env MY_VAR=value
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
I routinely run out of space on my Macbook's 256GB drive. I have `COLIMA_HOME` set on an external drive to hold the Lima disks, but it would be nice to have the cache directory there too.

I wasn't sure if we wanted to require the directory already exist (as we do with `$COLIMA_HOME`) or create the directory automatically (as we do with `$LIMA_HOME`), so I picked the latter (otherwise, it'll fall back silently to the default, which feels wrong if we're explicitly setting the env var).

Noted the new env var down in the FAQ file. Also moved where we talk about the env vars from #1522, since I thought it was a little confusing how it was written. Specifically, `COLIMA_HOME` / `COLIMA_PROFILE` / `DOCKER_CONFIG` are env vars for the host to configure the Colima CLI (or Docker CLI), whereas `--env` is used to inject env vars into the guest VM, so I tried to make that more clear.