### PR TITLE
net: support krunkit network.mode: shared

### DIFF
--- a/environment/vm/lima/daemon.go
+++ b/environment/vm/lima/daemon.go
@@ -14,8 +14,8 @@ import (
 )
 
 func (l *limaVM) startDaemon(ctx context.Context, conf config.Config) (context.Context, error) {
-	// vmnet is used by QEMU or bridged mode
-	useVmnet := conf.VMType == limaconfig.QEMU || conf.Network.Mode == "bridged"
+	// vmnet is used by QEMU, Krunkit, or bridged mode
+	useVmnet := conf.VMType == limaconfig.QEMU || conf.VMType == limaconfig.Krunkit || conf.Network.Mode == "bridged"
 
 	// network daemon is only needed for vmnet
 	conf.Network.Address = conf.Network.Address && useVmnet


### PR DESCRIPTION
This change should help addresses https://github.com/abiosoft/colima/issues/1559.  This change should allow for l2 announcements to work when using tools like metallb, cilium l2 announcements.

both lima & krunkit support socket_vmnet
* krunkit ≥ 1.0 supports virtio-net,type=unixstream,path=… (via libkrun krun_add_net_unixstream) https://github.com/containers/krunkit/pull/63
* lima ≥ 2.x's lima-driver-krunkit plumbs socket_vmnet https://github.com/lima-vm/lima/pull/4137

Verified that the templating adds another interface.
```sh
🍎 ❯ grep -A10 "^networks:" ~/.colima/_lima/colima-mtest/lima.yaml
networks:
    - lima: user-v2
    - socket: /Users/ep/.colima/mtest/daemon/vmnet.sock
      interface: col0
      metric: 300
provision:
    - mode: system
      script: sysctl -w fs.inotify.max_user_watches=1048576
    - mode: system
      script: grep '127.0.0.1 colima-mtest' /etc/hosts || echo '127.0.0.1 colima-mtest' >> /etc/hosts
    - mode: system
```

Will test tomorrow with finishing up a Kubernetes cluster and seeing if the L2 announcements work as expected.  

One step closer to having gpu accelerated pods running in Kubernetes!