### PR TITLE
docs: update krunkit installation to reference upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,7 @@ You can use the `incus` client on macOS after `colima start` with no additional 
 
 Colima supports GPU accelerated containers for AI workloads using the `krunkit` VM type.
 
-**Note:** To use krunkit with colima, ensure it is installed.
-
-```
-brew tap slp/krunkit
-brew install krunkit
-```
+**Note:** To use krunkit with colima, ensure it is installed.  Please follow their [installation instructions](https://github.com/containers/krunkit#installation)
 
 Setup and use a model.
 


### PR DESCRIPTION
Installation instructions for krunkit are out of date.  They've moved homebrew taps.  

Not sure if changing out the krunkit package installation will break existing VMs.  Instead of copy/pasting their upgrade instructions just putting their install link.


Also might be worth considering putting in the vmnet installation instructions somewhere.  The homebrew based installation that I initially reached for is not supported anymore.  https://lima-vm.io/docs/config/network/vmnet/#socket_vmnet