### PR TITLE
cli: show runtime for stopped instances in list output

### DIFF
--- a/environment/vm/lima/limautil/instance.go
+++ b/environment/vm/lima/limautil/instance.go
@@ -111,8 +111,8 @@ func Instances(ids ...string) ([]InstanceInfo, error) {
 					i.IPAddress = getIPAddress(i.Name, NetInterface)
 				}
 			}
-			i.Runtime = getRuntime(conf)
 		}
+		i.Runtime = getRuntime(conf)
 
 		// rename to local friendly names
 		i.Name = config.ProfileFromName(i.Name).ShortName


### PR DESCRIPTION
## Summary

- `colima list` left the `RUNTIME` column blank for stopped VMs because the runtime was assigned inside the `if i.Running()` branch in `Instances()`.
- The runtime is read from the on-disk state file via `i.Config()`, so it is available regardless of VM state — the same way `conf.Disk` is read just below the block.
- Moved `i.Runtime = getRuntime(conf)` outside the `Running()` check. The IP-address lookup, which genuinely needs a running VM, stays gated.

## Test plan

- [ ] `colima list` on a stopped instance shows `docker` (or the configured runtime) in the `RUNTIME` column instead of an empty field
- [ ] `colima list` on a running instance still shows the runtime and IP address as before
- [ ] `colima list --json` includes the `runtime` field for stopped instances

## LLM Usage Disclosure

This contribution was prepared with the assistance of an LLM (Claude). Specifically:

- **Investigation** — the LLM located the gated assignment in `environment/vm/lima/limautil/instance.go` and explained why it caused the empty `RUNTIME` column for stopped VMs.
- **Code change** — the one-line move of `i.Runtime = getRuntime(conf)` out of the `if i.Running()` block was generated by the LLM.
- **Commit message and PR body** — drafted by the LLM and reviewed by me before submission.

The change is a single-line move; I have read it and confirmed it is correct.
