### PR TITLE
vm: allow use of unsupported disk images

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -147,6 +147,7 @@ var startCmdArgs struct {
 		Edit                    bool
 		Editor                  string
 		ActivateRuntime         bool
+		ForceDiskImage          bool
 		Binfmt                  bool
 		DNSHosts                []string
 		Foreground              bool
@@ -192,6 +193,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Foreground, "foreground", "f", false, "Keep colima in the foreground")
 	startCmd.Flags().StringVar(&startCmdArgs.Hostname, "hostname", "", "custom hostname for the virtual machine")
 	startCmd.Flags().StringVarP(&startCmdArgs.DiskImage, "disk-image", "i", "", "file path to a custom disk image")
+	startCmd.Flags().BoolVar(&startCmdArgs.Flags.ForceDiskImage, "force-disk-image", false, "load unsupported disk image")
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.Template, "template", true, "use the template file for initial configuration")
 
 	// port forwarder
@@ -458,6 +460,7 @@ func prepareConfig(cmd *cobra.Command) {
 	startCmdArgs.Network.DNSHosts = dnsHostsFromFlag(startCmdArgs.Flags.DNSHosts)
 	startCmdArgs.ActivateRuntime = &startCmdArgs.Flags.ActivateRuntime
 	startCmdArgs.Binfmt = &startCmdArgs.Flags.Binfmt
+	startCmdArgs.ForceDiskImage = &startCmdArgs.Flags.ForceDiskImage
 
 	// handle legacy kubernetes-disable
 	for _, disable := range startCmdArgs.Flags.LegacyKubernetesDisable {
@@ -580,6 +583,11 @@ func prepareConfig(cmd *cobra.Command) {
 	if !cmd.Flag("binfmt").Changed {
 		if current.Binfmt != nil {
 			startCmdArgs.Binfmt = current.Binfmt
+		}
+	}
+	if !cmd.Flag("force-disk-image").Changed {
+		if current.ForceDiskImage != nil {
+			startCmdArgs.ForceDiskImage = current.ForceDiskImage
 		}
 	}
 	if !cmd.Flag("network-host-addresses").Changed {

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	Binfmt               *bool  `yaml:"binfmt,omitempty"`
 	NestedVirtualization bool   `yaml:"nestedVirtualization,omitempty"`
 	DiskImage            string `yaml:"diskImage,omitempty"`
+	ForceDiskImage       *bool  `yaml:"forceDiskImage,omitempty"`
 	PortForwarder        string `yaml:"portForwarder,omitempty"` // "ssh", "grpc"
 
 	// volume mounts

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -267,6 +267,10 @@ mounts: []
 # Default: ""
 diskImage: ""
 
+# Use the custom disk image even if it does NOT match a supported release image.
+# WARNING: This bypasses validating the image and is a completely unsupported!
+forceDiskImage: false
+
 # Size of the disk in GiB for the root filesystem of the virtual machine.
 # This value is ignored if no runtime is in use. i.e. `none` runtime.
 # Default: 20

--- a/environment/vm/lima/disk.go
+++ b/environment/vm/lima/disk.go
@@ -158,7 +158,12 @@ func (l *limaVM) downloadDiskImage(ctx context.Context, conf config.Config) erro
 
 		sha := downloader.SHA{Size: 512, Digest: image.Digest}
 		if err := sha.ValidateFile(l.host, conf.DiskImage); err != nil {
-			return fmt.Errorf("disk image must be downloaded from '%s', hash failure: %w", image.Location, err)
+			if conf.ForceDiskImage != nil && *conf.ForceDiskImage {
+				log.Warnln("unable to validate disk image, but continuing as requested...")
+				image.Digest = "" // clear so lima does not re-validate
+			} else {
+				return fmt.Errorf("disk image must be downloaded from '%s', hash failure: %w", image.Location, err)
+			}
 		}
 
 		image.Location = conf.DiskImage

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -163,6 +163,16 @@ func (l *limaVM) resume(ctx context.Context, conf config.Config) error {
 	a.Add(l.setDiskImage)
 
 	a.Add(func() error {
+		if conf.DiskImage != "" && conf.ForceDiskImage != nil && *conf.ForceDiskImage {
+			for i := range l.limaConf.Images {
+				l.limaConf.Images[i].Location = conf.DiskImage
+				l.limaConf.Images[i].Digest = ""
+			}
+		}
+		return nil
+	})
+
+	a.Add(func() error {
 		err := yamlutil.WriteYAML(l.limaConf, config.CurrentProfile().LimaFile())
 		return err
 	})


### PR DESCRIPTION
I've been testing colima with disk images based on alternate OS's (Debian) and kernels with various features forced on (eg. FIPS). Right now it requires me to run a custom build of colima to bypass the hash match restriction.

This patch simply provides a way for developers / power users to test custom disk images, not just mirrors of released images.