### PR TITLE
config: default to home mount when `mounts` key is absent

### DIFF
--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -44,6 +44,20 @@ func LoadFrom(file string) (config.Config, error) {
 		return c, fmt.Errorf("could not load config from file: %w", err)
 	}
 
+	// yaml.Unmarshal collapses both an absent `mounts` key and an explicit
+	// `mounts: null` into a nil slice, but they mean different things: an absent
+	// key falls back to the documented default (mount $HOME, i.e. an empty list),
+	// whereas an explicit null disables mounts. Restore the default for the
+	// absent case by inspecting the raw document for the key's presence.
+	if c.Mounts == nil {
+		var raw map[string]yaml.Node
+		if yaml.Unmarshal(b, &raw) == nil {
+			if _, present := raw["mounts"]; !present {
+				c.Mounts = []config.Mount{}
+			}
+		}
+	}
+
 	return c, nil
 }
 

--- a/config/configmanager/configmanager_test.go
+++ b/config/configmanager/configmanager_test.go
@@ -1,0 +1,76 @@
+package configmanager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadFromMounts ensures the three mount states round-trip correctly when
+// loading a config file. In particular, an absent `mounts` key must fall back
+// to the documented default (mount $HOME) rather than being treated the same as
+// an explicit `mounts: null` (no mounts). See issue #1533.
+func TestLoadFromMounts(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		// wantHome is the expected result of MountsOrDefault containing the
+		// default home mount.
+		wantHome bool
+		wantLen  int
+	}{
+		{
+			name:     "absent key defaults to home",
+			content:  "cpu: 4\nmemory: 8\n",
+			wantHome: true,
+			wantLen:  1,
+		},
+		{
+			name:     "explicit empty list defaults to home",
+			content:  "cpu: 4\nmounts: []\n",
+			wantHome: true,
+			wantLen:  1,
+		},
+		{
+			name:     "explicit null disables mounts",
+			content:  "cpu: 4\nmounts: null\n",
+			wantHome: false,
+			wantLen:  0,
+		},
+		{
+			name:     "explicit mounts are preserved",
+			content:  "cpu: 4\nmounts:\n  - location: /x\n",
+			wantHome: false,
+			wantLen:  1,
+		},
+	}
+
+	dir := t.TempDir()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := filepath.Join(dir, tt.name+".yaml")
+			if err := os.WriteFile(f, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			c, err := LoadFrom(f)
+			if err != nil {
+				t.Fatalf("LoadFrom() error = %v", err)
+			}
+
+			mounts := c.MountsOrDefault()
+			if len(mounts) != tt.wantLen {
+				t.Errorf("MountsOrDefault() len = %d, want %d", len(mounts), tt.wantLen)
+			}
+			if tt.wantHome {
+				if len(mounts) != 1 {
+					t.Fatalf("expected single default home mount, got %d", len(mounts))
+				}
+				home, err := os.UserHomeDir()
+				if err == nil && mounts[0].Location != home {
+					t.Errorf("default mount location = %q, want home %q", mounts[0].Location, home)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

An absent `mounts:` key and an explicit `mounts: null` both unmarshal to a nil slice, but Colima's config layer assigns them different meanings ([`config/config.go`](https://github.com/abiosoft/colima/blob/main/config/config.go) — `MountsOrDefault`):

- `nil` → no mounts
- `[]` (empty list) → default: mount `$HOME`
- `[…]` → explicit mounts

Because `yaml.Unmarshal` collapses an *absent* key and `mounts: null` into the same nil slice, removing the `mounts:` line from a config file is treated as "no mounts" instead of the documented default (mount `$HOME`). The home directory silently stops being mounted.

This reproduces the report in #1533. The normal save path doesn't hit it because `yamlutil.Save` merges into the embedded default template (which carries `mounts: []`); it only surfaces when the key is hand-removed.

## Fix

In `LoadFrom`, after unmarshaling, detect the absent-key case by inspecting the raw document for the key's presence. When the key is absent, restore the empty-list default (mount `$HOME`). An explicit `mounts: null` keeps the key present and is left untouched, so the `--mount=none` behaviour added in #1485 is preserved.

| config | before | after |
|---|---|---|
| (no `mounts:` key) | no mounts | **mount $HOME** |
| `mounts: []` | mount $HOME | mount $HOME |
| `mounts: null` | no mounts | no mounts |
| `mounts: [...]` | explicit | explicit |

## Tests

Adds `TestLoadFromMounts` covering all four states. `go build ./...`, `go vet ./...`, `gofmt`, and `go test ./...` all pass.

Fixes #1533