### PR TITLE
cli: add --registry-mirror flag to start command

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -475,6 +475,9 @@ func prepareConfig(cmd *cobra.Command) {
 	startCmdArgs.ActivateRuntime = &startCmdArgs.Flags.ActivateRuntime
 	startCmdArgs.Binfmt = &startCmdArgs.Flags.Binfmt
 	startCmdArgs.ForceDiskImage = &startCmdArgs.Flags.ForceDiskImage
+	if cmd.Flag("registry-mirror").Changed {
+		startCmdArgs.Docker = withRegistryMirrors(startCmdArgs.Docker, startCmdArgs.Flags.RegistryMirrors)
+	}
 
 	// handle legacy kubernetes-disable
 	for _, disable := range startCmdArgs.Flags.LegacyKubernetesDisable {
@@ -499,9 +502,6 @@ func prepareConfig(cmd *cobra.Command) {
 
 		if !templateUsed {
 			// use default config if there is no template or template is disabled
-			if cmd.Flag("registry-mirror").Changed {
-				startCmdArgs.Docker = withRegistryMirrors(startCmdArgs.Docker, startCmdArgs.Flags.RegistryMirrors)
-			}
 			return
 		}
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -150,6 +150,7 @@ var startCmdArgs struct {
 		ForceDiskImage          bool
 		Binfmt                  bool
 		DNSHosts                []string
+		RegistryMirrors         []string
 		Foreground              bool
 		SaveConfig              bool
 		LegacyCPU               int // for backward compatibility
@@ -269,6 +270,9 @@ func init() {
 	startCmd.Flags().IPSliceVarP(&startCmdArgs.Network.DNSResolvers, "dns", "n", nil, "DNS resolvers for the VM")
 	startCmd.Flags().StringSliceVar(&startCmdArgs.Flags.DNSHosts, "dns-host", nil, "custom DNS names to provide to resolver")
 
+	// docker
+	startCmd.Flags().StringSliceVar(&startCmdArgs.Flags.RegistryMirrors, "registry-mirror", nil, "registry mirrors to configure for docker, e.g. https://mirror.gcr.io")
+
 	// download options
 	startCmd.Flags().StringVar(&startCmdArgs.Flags.Downloader, "downloader", downloader.DownloaderNative, "downloader to use (native, curl)")
 }
@@ -288,6 +292,16 @@ func dnsHostsFromFlag(hosts []string) map[string]string {
 		mapping[src] = target
 	}
 	return mapping
+}
+
+// withRegistryMirrors returns the docker config with the registry-mirrors key
+// set to the provided mirrors, initializing the map if necessary.
+func withRegistryMirrors(docker map[string]any, mirrors []string) map[string]any {
+	if docker == nil {
+		docker = map[string]any{}
+	}
+	docker["registry-mirrors"] = mirrors
+	return docker
 }
 
 // mountsFromFlag converts mounts from cli flag format to config file format
@@ -485,6 +499,9 @@ func prepareConfig(cmd *cobra.Command) {
 
 		if !templateUsed {
 			// use default config if there is no template or template is disabled
+			if cmd.Flag("registry-mirror").Changed {
+				startCmdArgs.Docker = withRegistryMirrors(startCmdArgs.Docker, startCmdArgs.Flags.RegistryMirrors)
+			}
 			return
 		}
 	}
@@ -492,8 +509,11 @@ func prepareConfig(cmd *cobra.Command) {
 	// set missing defaults in the current config
 	setConfigDefaults(&current)
 
-	// docker can only be set in config file
+	// docker can only be set in config file, except registry mirrors via flag
 	startCmdArgs.Docker = current.Docker
+	if cmd.Flag("registry-mirror").Changed {
+		startCmdArgs.Docker = withRegistryMirrors(startCmdArgs.Docker, startCmdArgs.Flags.RegistryMirrors)
+	}
 	// provision scripts can only be set in config file
 	startCmdArgs.Provision = current.Provision
 

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -65,3 +65,45 @@ func Test_mountsFromFlag(t *testing.T) {
 		})
 	}
 }
+
+func Test_withRegistryMirrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		docker  map[string]any
+		mirrors []string
+		want    map[string]any
+	}{
+		{
+			name:    "nil map",
+			docker:  nil,
+			mirrors: []string{"https://mirror.gcr.io"},
+			want: map[string]any{
+				"registry-mirrors": []string{"https://mirror.gcr.io"},
+			},
+		},
+		{
+			name:    "existing keys preserved",
+			docker:  map[string]any{"insecure-registries": []string{"host.docker.internal:5000"}},
+			mirrors: []string{"https://mirror.gcr.io"},
+			want: map[string]any{
+				"insecure-registries": []string{"host.docker.internal:5000"},
+				"registry-mirrors":    []string{"https://mirror.gcr.io"},
+			},
+		},
+		{
+			name:    "existing mirrors replaced",
+			docker:  map[string]any{"registry-mirrors": []string{"https://old.mirror"}},
+			mirrors: []string{"https://new.mirror"},
+			want: map[string]any{
+				"registry-mirrors": []string{"https://new.mirror"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := withRegistryMirrors(tt.docker, tt.mirrors); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("withRegistryMirrors() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -277,6 +277,12 @@ colima start --edit
 +     - https://my.quayio.mirror.something
 ```
 
+Registry mirrors can also be set directly on start with the repeatable `--registry-mirror` flag, without editing the config:
+
+```sh
+colima start --registry-mirror https://my.dockerhub.mirror.something --registry-mirror https://my.quayio.mirror.something
+```
+
 As an alternative approach to the **colima start --edit**, make the changes via the **template** command (affecting the configuration for any new instances):
 
 ```sh


### PR DESCRIPTION
Add a repeatable --registry-mirror flag as a CLI convenience for configuring docker registry mirrors without editing the config file. The values are injected into the docker daemon.json registry-mirrors key, which was previously only settable via the `docker:` config block.

Closes #1445