### PR TITLE
core: add --disk-image-mirror flag to download images from a mirror

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -194,6 +194,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Foreground, "foreground", "f", false, "Keep colima in the foreground")
 	startCmd.Flags().StringVar(&startCmdArgs.Hostname, "hostname", "", "custom hostname for the virtual machine")
 	startCmd.Flags().StringVarP(&startCmdArgs.DiskImage, "disk-image", "i", "", "file path to a custom disk image")
+	startCmd.Flags().StringVar(&startCmdArgs.DiskImageMirror, "disk-image-mirror", "", "mirror URL to replace the https://github.com prefix when downloading disk images")
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.ForceDiskImage, "force-disk-image", false, "load unsupported disk image")
 	startCmd.Flags().BoolVar(&startCmdArgs.Flags.Template, "template", true, "use the template file for initial configuration")
 
@@ -609,6 +610,9 @@ func prepareConfig(cmd *cobra.Command) {
 		if current.ForceDiskImage != nil {
 			startCmdArgs.ForceDiskImage = current.ForceDiskImage
 		}
+	}
+	if !cmd.Flag("disk-image-mirror").Changed {
+		startCmdArgs.DiskImageMirror = current.DiskImageMirror
 	}
 	if !cmd.Flag("network-host-addresses").Changed {
 		startCmdArgs.Network.HostAddresses = current.Network.HostAddresses

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	Binfmt               *bool  `yaml:"binfmt,omitempty"`
 	NestedVirtualization bool   `yaml:"nestedVirtualization,omitempty"`
 	DiskImage            string `yaml:"diskImage,omitempty"`
+	DiskImageMirror      string `yaml:"diskImageMirror,omitempty"`
 	ForceDiskImage       *bool  `yaml:"forceDiskImage,omitempty"`
 	PortForwarder        string `yaml:"portForwarder,omitempty"` // "ssh", "grpc"
 

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -267,6 +267,14 @@ mounts: []
 # Default: ""
 diskImage: ""
 
+# Mirror to download the disk image from, replacing the https://github.com
+# prefix of the image URL. Useful behind a proxy or registry that mirrors
+# GitHub release assets. The sha512 checksum is still verified after download.
+#
+# EXAMPLE: https://artifactory.mycompany.com/artifactory/github
+# Default: ""
+diskImageMirror: ""
+
 # Use the custom disk image even if it does NOT match a supported release image.
 # WARNING: This bypasses validating the image and is a completely unsupported!
 forceDiskImage: false

--- a/environment/vm/lima/disk.go
+++ b/environment/vm/lima/disk.go
@@ -172,14 +172,14 @@ func (l *limaVM) downloadDiskImage(ctx context.Context, conf config.Config) erro
 	}
 
 	// use a previously cached image
-	if image, ok := limautil.ImageCached(l.limaConf.Arch, conf.Runtime); ok {
+	if image, ok := limautil.ImageCached(l.limaConf.Arch, conf.Runtime, conf.DiskImageMirror); ok {
 		l.limaConf.Images = []limaconfig.File{image}
 		return nil
 	}
 
 	// download image
 	log.Infoln("downloading disk image ...")
-	image, err := limautil.DownloadImage(l.limaConf.Arch, conf.Runtime)
+	image, err := limautil.DownloadImage(l.limaConf.Arch, conf.Runtime, conf.DiskImageMirror)
 	if err != nil {
 		return fmt.Errorf("error getting qcow image: %w", err)
 	}

--- a/environment/vm/lima/limautil/image.go
+++ b/environment/vm/lima/limautil/image.go
@@ -23,13 +23,27 @@ func init() {
 	}
 }
 
+// imageURLHost is the host prefix of the disk image URLs in images/images.txt.
+// It is the part replaced when a disk image mirror is configured.
+const imageURLHost = "https://github.com"
+
+// mirrorURL replaces the github.com prefix of a disk image URL with the given
+// mirror. A non-github URL or an empty mirror is returned unchanged.
+func mirrorURL(rawurl, mirror string) string {
+	if mirror == "" || !strings.HasPrefix(rawurl, imageURLHost) {
+		return rawurl
+	}
+	return strings.TrimSuffix(mirror, "/") + strings.TrimPrefix(rawurl, imageURLHost)
+}
+
 // ImageCached returns if the image for architecture and runtime
 // has been previously downloaded and cached.
-func ImageCached(arch environment.Arch, runtime string) (limaconfig.File, bool) {
+func ImageCached(arch environment.Arch, runtime, mirror string) (limaconfig.File, bool) {
 	img, err := findImage(arch, runtime)
 	if err != nil {
 		return img, false
 	}
+	img.Location = mirrorURL(img.Location, mirror)
 
 	image := diskImageFile(downloader.CacheFilename(img.Location))
 
@@ -59,11 +73,12 @@ func Image(arch environment.Arch, runtime string) (limaconfig.File, error) {
 }
 
 // DownloadImage downloads the image for arch and runtime.
-func DownloadImage(arch environment.Arch, runtime string) (f limaconfig.File, err error) {
+func DownloadImage(arch environment.Arch, runtime, mirror string) (f limaconfig.File, err error) {
 	img, err := findImage(arch, runtime)
 	if err != nil {
 		return img, err
 	}
+	img.Location = mirrorURL(img.Location, mirror)
 
 	host := host.New()
 	// download image

--- a/environment/vm/lima/limautil/image_test.go
+++ b/environment/vm/lima/limautil/image_test.go
@@ -1,0 +1,46 @@
+package limautil
+
+import "testing"
+
+func Test_mirrorURL(t *testing.T) {
+	const ghURL = "https://github.com/abiosoft/colima-core/releases/download/v0.10.4/img.raw.gz"
+
+	tests := []struct {
+		name   string
+		url    string
+		mirror string
+		want   string
+	}{
+		{
+			name:   "empty mirror returns url unchanged",
+			url:    ghURL,
+			mirror: "",
+			want:   ghURL,
+		},
+		{
+			name:   "github prefix replaced",
+			url:    ghURL,
+			mirror: "https://artifactory.mycompany.com/artifactory/github",
+			want:   "https://artifactory.mycompany.com/artifactory/github/abiosoft/colima-core/releases/download/v0.10.4/img.raw.gz",
+		},
+		{
+			name:   "mirror trailing slash does not double up",
+			url:    ghURL,
+			mirror: "https://artifactory.mycompany.com/artifactory/github/",
+			want:   "https://artifactory.mycompany.com/artifactory/github/abiosoft/colima-core/releases/download/v0.10.4/img.raw.gz",
+		},
+		{
+			name:   "non-github url returned unchanged",
+			url:    "https://example.com/abiosoft/img.raw.gz",
+			mirror: "https://artifactory.mycompany.com/artifactory/github",
+			want:   "https://example.com/abiosoft/img.raw.gz",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mirrorURL(tt.url, tt.mirror); got != tt.want {
+				t.Errorf("mirrorURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow replacing the https://github.com prefix of the disk image URL with a mirror (e.g. an Artifactory proxying GitHub releases). The sha512 checksum is still validated after download, so a mirror cannot serve tampered images.

Closes #1438