### PR TITLE
add physical disk mounts with native VZ backend

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -517,6 +517,8 @@ func prepareConfig(cmd *cobra.Command) {
 	}
 	// provision scripts can only be set in config file
 	startCmdArgs.Provision = current.Provision
+	// physical disks can only be set in config file
+	startCmdArgs.PhysicalDisks = current.PhysicalDisks
 
 	// use current settings for unchanged configs
 	// otherwise may be reverted to their default values.

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,9 @@ type Config struct {
 	MountType    string  `yaml:"mountType,omitempty"`
 	MountINotify bool    `yaml:"mountInotify,omitempty"`
 
+	// physical block devices mounted inside the VM.
+	PhysicalDisks []PhysicalDisk `yaml:"physicalDisks,omitempty"`
+
 	// Runtime is one of docker, containerd.
 	Runtime         string `yaml:"runtime,omitempty"`
 	ActivateRuntime *bool  `yaml:"autoActivate,omitempty"`
@@ -101,6 +104,25 @@ type Mount struct {
 	Location   string `yaml:"location"`
 	MountPoint string `yaml:"mountPoint,omitempty"`
 	Writable   bool   `yaml:"writable"`
+}
+
+// PhysicalDisk is a host block device exposed to the VM and mounted there.
+type PhysicalDisk struct {
+	Name       string                 `yaml:"name"`
+	Device     string                 `yaml:"device"`
+	RawDevice  string                 `yaml:"rawDevice,omitempty"`
+	FSType     string                 `yaml:"fsType,omitempty"`
+	Writable   bool                   `yaml:"writable"`
+	MountPoint string                 `yaml:"mountPoint,omitempty"`
+	Backend    string                 `yaml:"backend,omitempty"`
+	HostAccess PhysicalDiskHostAccess `yaml:"hostAccess,omitempty"`
+}
+
+// PhysicalDiskHostAccess exposes a VM-mounted physical disk back to the host.
+type PhysicalDiskHostAccess struct {
+	Enabled    bool   `yaml:"enabled"`
+	Driver     string `yaml:"driver,omitempty"`
+	MountPoint string `yaml:"mountPoint,omitempty"`
 }
 
 // Provision modes managed by Colima (not passed to Lima).

--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -100,14 +100,14 @@ func ValidateConfig(c config.Config) error {
 		}
 	}
 
-	if err := validatePhysicalDisks(c.PhysicalDisks); err != nil {
+	if err := validatePhysicalDisks(c.PhysicalDisks, c.VMType); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func validatePhysicalDisks(disks []config.PhysicalDisk) error {
+func validatePhysicalDisks(disks []config.PhysicalDisk, vmType string) error {
 	if len(disks) == 0 {
 		return nil
 	}
@@ -157,6 +157,10 @@ func validatePhysicalDisks(disks []config.PhysicalDisk) error {
 
 		switch disk.Backend {
 		case "", "auto", "nbd":
+		case "vz":
+			if vmType != "vz" {
+				return fmt.Errorf("physicalDisks.%s backend %q requires vmType: vz", disk.Name, disk.Backend)
+			}
 		default:
 			return fmt.Errorf("physicalDisks.%s backend %q is unsupported", disk.Name, disk.Backend)
 		}

--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/abiosoft/colima/config"
@@ -95,6 +97,101 @@ func ValidateConfig(c config.Config) error {
 	if c.Network.GatewayAddress != nil {
 		if err := validateGatewayAddress(c.Network.GatewayAddress); err != nil {
 			return err
+		}
+	}
+
+	if err := validatePhysicalDisks(c.PhysicalDisks); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validatePhysicalDisks(disks []config.PhysicalDisk) error {
+	if len(disks) == 0 {
+		return nil
+	}
+	if !util.MacOS() {
+		return fmt.Errorf("physicalDisks is currently only supported on macOS")
+	}
+
+	validName := regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+	validDiskDevice := regexp.MustCompile(`^disk[0-9]+s[0-9]+$`)
+	validRawDiskDevice := regexp.MustCompile(`^rdisk[0-9]+s[0-9]+$`)
+	seenNames := map[string]bool{}
+	seenDevices := map[string]string{}
+	seenGuestMounts := map[string]string{}
+	seenHostMounts := map[string]string{}
+
+	for _, disk := range disks {
+		if disk.Name == "" {
+			return fmt.Errorf("physicalDisks entries require a name")
+		}
+		if !validName.MatchString(disk.Name) {
+			return fmt.Errorf("invalid physicalDisks name %q: use letters, numbers, dot, underscore, or dash", disk.Name)
+		}
+		if seenNames[disk.Name] {
+			return fmt.Errorf("duplicate physicalDisks name %q", disk.Name)
+		}
+		seenNames[disk.Name] = true
+
+		if disk.Device == "" {
+			return fmt.Errorf("physicalDisks.%s requires device", disk.Name)
+		}
+		if !filepath.IsAbs(disk.Device) || !strings.HasPrefix(disk.Device, "/dev/disk") {
+			return fmt.Errorf("physicalDisks.%s device must be an absolute /dev/diskNsM path", disk.Name)
+		}
+		if !validDiskDevice.MatchString(filepath.Base(disk.Device)) {
+			return fmt.Errorf("physicalDisks.%s must target a partition, not a whole disk", disk.Name)
+		}
+		if other := seenDevices[disk.Device]; other != "" {
+			return fmt.Errorf("physicalDisks.%s uses the same device as physicalDisks.%s", disk.Name, other)
+		}
+		seenDevices[disk.Device] = disk.Name
+
+		if disk.RawDevice != "" {
+			if !filepath.IsAbs(disk.RawDevice) || !validRawDiskDevice.MatchString(filepath.Base(disk.RawDevice)) {
+				return fmt.Errorf("physicalDisks.%s rawDevice must be an absolute /dev/rdiskNsM path", disk.Name)
+			}
+		}
+
+		switch disk.Backend {
+		case "", "auto", "nbd":
+		default:
+			return fmt.Errorf("physicalDisks.%s backend %q is unsupported", disk.Name, disk.Backend)
+		}
+
+		switch disk.FSType {
+		case "", "auto", "ext4", "xfs", "btrfs":
+		default:
+			return fmt.Errorf("physicalDisks.%s fsType %q is unsupported", disk.Name, disk.FSType)
+		}
+
+		if disk.MountPoint != "" {
+			if !filepath.IsAbs(disk.MountPoint) {
+				return fmt.Errorf("physicalDisks.%s mountPoint must be absolute", disk.Name)
+			}
+			if other := seenGuestMounts[disk.MountPoint]; other != "" {
+				return fmt.Errorf("physicalDisks.%s uses the same mountPoint as physicalDisks.%s", disk.Name, other)
+			}
+			seenGuestMounts[disk.MountPoint] = disk.Name
+		}
+
+		if disk.HostAccess.Enabled {
+			switch disk.HostAccess.Driver {
+			case "", "nfs":
+			default:
+				return fmt.Errorf("physicalDisks.%s hostAccess.driver %q is unsupported", disk.Name, disk.HostAccess.Driver)
+			}
+			if disk.HostAccess.MountPoint != "" {
+				if !filepath.IsAbs(disk.HostAccess.MountPoint) {
+					return fmt.Errorf("physicalDisks.%s hostAccess.mountPoint must be absolute", disk.Name)
+				}
+				if other := seenHostMounts[disk.HostAccess.MountPoint]; other != "" {
+					return fmt.Errorf("physicalDisks.%s uses the same hostAccess.mountPoint as physicalDisks.%s", disk.Name, other)
+				}
+				seenHostMounts[disk.HostAccess.MountPoint] = disk.Name
+			}
 		}
 	}
 

--- a/config/configmanager/physical_disk_test.go
+++ b/config/configmanager/physical_disk_test.go
@@ -15,11 +15,13 @@ func TestValidatePhysicalDisks(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		vmType  string
 		disks   []config.PhysicalDisk
 		wantErr string
 	}{
 		{
-			name: "valid writable nfs disk",
+			name:   "valid writable nfs disk",
+			vmType: "qemu",
 			disks: []config.PhysicalDisk{
 				{
 					Name:      "src",
@@ -36,21 +38,39 @@ func TestValidatePhysicalDisks(t *testing.T) {
 			},
 		},
 		{
-			name: "whole disk rejected",
+			name:   "whole disk rejected",
+			vmType: "qemu",
 			disks: []config.PhysicalDisk{
 				{Name: "src", Device: "/dev/disk0"},
 			},
 			wantErr: "must target a partition",
 		},
 		{
-			name: "unsupported filesystem",
+			name:   "unsupported filesystem",
+			vmType: "qemu",
 			disks: []config.PhysicalDisk{
 				{Name: "src", Device: "/dev/disk0s6", FSType: "apfs"},
 			},
 			wantErr: "fsType",
 		},
 		{
-			name: "duplicate host mountpoint",
+			name:   "valid vz backend",
+			vmType: "vz",
+			disks: []config.PhysicalDisk{
+				{Name: "src", Device: "/dev/disk0s6", Backend: "vz"},
+			},
+		},
+		{
+			name:   "vz backend requires vz vm",
+			vmType: "qemu",
+			disks: []config.PhysicalDisk{
+				{Name: "src", Device: "/dev/disk0s6", Backend: "vz"},
+			},
+			wantErr: "requires vmType: vz",
+		},
+		{
+			name:   "duplicate host mountpoint",
+			vmType: "qemu",
 			disks: []config.PhysicalDisk{
 				{Name: "one", Device: "/dev/disk0s6", HostAccess: config.PhysicalDiskHostAccess{Enabled: true, MountPoint: "/Volumes/Colima/src"}},
 				{Name: "two", Device: "/dev/disk0s7", HostAccess: config.PhysicalDiskHostAccess{Enabled: true, MountPoint: "/Volumes/Colima/src"}},
@@ -61,7 +81,7 @@ func TestValidatePhysicalDisks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePhysicalDisks(tt.disks)
+			err := validatePhysicalDisks(tt.disks, tt.vmType)
 			if tt.wantErr == "" && err != nil {
 				t.Fatalf("validatePhysicalDisks() error = %v", err)
 			}

--- a/config/configmanager/physical_disk_test.go
+++ b/config/configmanager/physical_disk_test.go
@@ -1,0 +1,78 @@
+package configmanager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/util"
+)
+
+func TestValidatePhysicalDisks(t *testing.T) {
+	if !util.MacOS() {
+		t.Skip("physicalDisks validation is currently macOS-specific")
+	}
+
+	tests := []struct {
+		name    string
+		disks   []config.PhysicalDisk
+		wantErr string
+	}{
+		{
+			name: "valid writable nfs disk",
+			disks: []config.PhysicalDisk{
+				{
+					Name:      "src",
+					Device:    "/dev/disk0s6",
+					RawDevice: "/dev/rdisk0s6",
+					FSType:    "ext4",
+					Writable:  true,
+					HostAccess: config.PhysicalDiskHostAccess{
+						Enabled:    true,
+						Driver:     "nfs",
+						MountPoint: "/Volumes/Colima/src",
+					},
+				},
+			},
+		},
+		{
+			name: "whole disk rejected",
+			disks: []config.PhysicalDisk{
+				{Name: "src", Device: "/dev/disk0"},
+			},
+			wantErr: "must target a partition",
+		},
+		{
+			name: "unsupported filesystem",
+			disks: []config.PhysicalDisk{
+				{Name: "src", Device: "/dev/disk0s6", FSType: "apfs"},
+			},
+			wantErr: "fsType",
+		},
+		{
+			name: "duplicate host mountpoint",
+			disks: []config.PhysicalDisk{
+				{Name: "one", Device: "/dev/disk0s6", HostAccess: config.PhysicalDiskHostAccess{Enabled: true, MountPoint: "/Volumes/Colima/src"}},
+				{Name: "two", Device: "/dev/disk0s7", HostAccess: config.PhysicalDiskHostAccess{Enabled: true, MountPoint: "/Volumes/Colima/src"}},
+			},
+			wantErr: "hostAccess.mountPoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePhysicalDisks(tt.disks)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("validatePhysicalDisks() error = %v", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("validatePhysicalDisks() expected error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("validatePhysicalDisks() error = %v, want containing %q", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -489,7 +489,7 @@ __Note:__ This feature is available from Version 0.5.3.
 
 ## Can Colima mount a physical disk partition?
 
-Yes. macOS physical disk partitions can be attached to the VM with the `physicalDisks` configuration and optionally mounted back on macOS through NFS.
+Yes. macOS physical disk partitions can be attached to the VM with the `physicalDisks` configuration using either the NBD backend or native VZ block attachment when the Lima/VZ requirements are met. They can also be mounted back on macOS through NFS.
 
 See [Physical Disks](PHYSICAL_DISKS.md) for configuration, safety notes, and troubleshooting.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -42,6 +42,7 @@
     - [Automatic](#automatic)
     - [Manual](#manual)
   - [How can disk size be increased?](#how-can-disk-size-be-increased)
+  - [Can Colima mount a physical disk partition?](#can-colima-mount-a-physical-disk-partition)
   - [Are Lima overrides supported?](#are-lima-overrides-supported)
     - [Example: Adding provision scripts](#example-adding-provision-scripts)
   - [How can the VM and its tools be updated?](#how-can-the-vm-and-its-tools-be-updated)
@@ -485,6 +486,12 @@ Disk size is automatically increased on start up based on configuration in `coli
 
 __Note:__ This feature is available from Version 0.5.3.
 
+
+## Can Colima mount a physical disk partition?
+
+Yes. macOS physical disk partitions can be attached to the VM with the `physicalDisks` configuration and optionally mounted back on macOS through NFS.
+
+See [Physical Disks](PHYSICAL_DISKS.md) for configuration, safety notes, and troubleshooting.
 
 ## Are Lima overrides supported?
 

--- a/docs/PHYSICAL_DISKS.md
+++ b/docs/PHYSICAL_DISKS.md
@@ -27,6 +27,23 @@ physicalDisks:
       mountPoint: /Volumes/Colima/src
 ```
 
+For native Virtualization.Framework block attachment, use `vmType: vz` and `backend: vz`:
+
+```yaml
+vmType: vz
+physicalDisks:
+  - name: src
+    device: /dev/disk0s6
+    fsType: ext4
+    writable: true
+    mountPoint: /mnt/colima/physical/src
+    backend: vz
+    hostAccess:
+      enabled: true
+      driver: nfs
+      mountPoint: /Volumes/Colima/src
+```
+
 Start or restart Colima after editing the profile config:
 
 ```sh
@@ -36,7 +53,7 @@ colima restart
 
 The disk is mounted in the VM at `mountPoint`. When `hostAccess.enabled` is true, Colima also mounts the VM export on macOS at `hostAccess.mountPoint`.
 
-Colima uses `sudo` on macOS only for operations that require host root privileges: opening the raw partition through `qemu-nbd`, mounting the NFS export on macOS, and cleaning those resources up. Guest setup also uses `sudo` inside the VM to connect `/dev/nbdN`, mount the filesystem, and manage the NFS export.
+Colima uses `sudo` on macOS only for operations that require host root privileges. With `backend: nbd`, Colima uses host `sudo` to open the raw partition through `qemu-nbd`, mount the NFS export on macOS, and clean those resources up. With `backend: vz`, Colima does not open the host disk itself; Lima's VZ block-device helper handles the privileged disk open during VM startup, and Colima still uses host `sudo` only for the optional macOS NFS mount. Guest setup uses `sudo` inside the VM to mount the filesystem and manage the optional NFS export.
 
 ## Configuration
 
@@ -48,18 +65,46 @@ Colima uses `sudo` on macOS only for operations that require host root privilege
 | `fsType` | no | `auto`, `ext4`, `xfs`, or `btrfs`. Defaults to `auto`. |
 | `writable` | no | Mount read-write when true. Defaults to read-only. |
 | `mountPoint` | no | VM mount point. Defaults to `/mnt/colima/physical/<name>`. |
-| `backend` | no | `auto` or `nbd`. Defaults to `auto`, currently resolved to `nbd`. |
+| `backend` | no | `auto`, `nbd`, or `vz`. Defaults to `auto`, currently resolved to `nbd`. |
 | `hostAccess.enabled` | no | Mount the VM filesystem back on macOS. |
 | `hostAccess.driver` | no | `nfs`. |
 | `hostAccess.mountPoint` | no | macOS mount point. Defaults to `/Volumes/Colima/<name>`. |
 
 When `hostAccess.enabled` is true, keep `mountPoint` under `/mnt/colima/physical`. Colima exports `/mnt/colima/physical` as the NFSv4 pseudo-root and mounts the disk on macOS as `localhost:/<name>`.
 
-## How It Works
+## Backends
+
+### NBD
 
 Colima uses `qemu-nbd` on macOS to expose the raw partition to the VM. The NBD service is bound to `127.0.0.1` and is reachable from the VM through an SSH reverse tunnel, not through the LAN.
 
 Inside the VM, Colima connects the export to `/dev/nbdN`, verifies the filesystem type with `blkid`, and mounts it at `mountPoint`.
+
+### VZ
+
+With `backend: vz`, Colima writes the partition path to Lima's `blockDevices` YAML field. Lima attaches the host partition to the VM through macOS Virtualization.Framework before the guest boots. Inside Linux, Colima mounts the stable virtio device path `/dev/disk/by-id/virtio-<device>`, for example `/dev/disk/by-id/virtio-disk0s6`.
+
+This backend requires:
+
+- `vmType: vz`
+- macOS 14 or newer
+- a Lima build with secure VZ block-device support, including `limactl sudoers --block-device`
+- an installed Lima sudoers file generated with the explicit block-device opt-in
+
+Example Lima sudoers setup:
+
+```sh
+limactl sudoers --block-device >etc_sudoers.d_lima
+less etc_sudoers.d_lima
+sudo install -o root etc_sudoers.d_lima /etc/sudoers.d/lima
+rm etc_sudoers.d_lima
+```
+
+`backend: vz` is faster for VM-side workloads because the guest sees a native virtio block device instead of a network block device. Host access from macOS still uses NFS because macOS does not mount Linux filesystems such as ext4 natively.
+
+For read-only configurations, Colima mounts the filesystem read-only in the guest. The current Lima VZ block-device contract does not provide a host-enforced read-only flag, so use `backend: nbd` if host-enforced read-only block access is required.
+
+## Host Access
 
 When host access is enabled, Colima starts an NFS server in the VM and mounts it on macOS through an SSH local tunnel. macOS sees an NFS mount; the Linux VM remains the only machine mounting the physical filesystem directly.
 
@@ -75,7 +120,8 @@ Check the mounted filesystem in the VM:
 
 ```sh
 colima ssh -- findmnt /mnt/colima/physical/src
-colima ssh -- blkid /dev/nbd0
+colima ssh -- blkid /dev/nbd0 # backend: nbd
+colima ssh -- blkid /dev/disk/by-id/virtio-disk0s6 # backend: vz
 ```
 
 If Colima reports that a writable disk is mounted on macOS, unmount it first:
@@ -94,6 +140,6 @@ colima stop --force
 ## Limitations
 
 - Physical disks are currently macOS-only.
-- The implemented backend is NBD. Native VZ block device attachment can be added later without changing the `physicalDisks` user-facing schema.
+- `backend: vz` requires `vmType: vz` and a Lima build with secure VZ block-device support.
 - Writable mode requires the filesystem to be mounted by Colima only.
 - Host access requires the macOS NFS client and the VM NFS server.

--- a/docs/PHYSICAL_DISKS.md
+++ b/docs/PHYSICAL_DISKS.md
@@ -1,0 +1,99 @@
+# Physical Disks
+
+Colima can attach macOS physical disk partitions to the VM and mount them as Linux filesystems. The mounted filesystem can also be exposed back to macOS through NFS, so host tools and containers can use the same files.
+
+This is intended for Linux filesystems such as `ext4`, `xfs`, or `btrfs` that macOS does not mount natively.
+
+A physical partition is useful for source trees and other working data that should outlive the Colima VM. The VM disk can be deleted, recreated, or corrupted during troubleshooting; keeping code on a separate host partition lets the VM stay disposable while new changes remain outside the VM image. This is not a replacement for backups, but it reduces the blast radius of VM lifecycle mistakes.
+
+> **Warning**
+>
+> Writable physical disks are dangerous. Do not mount or write to the same filesystem from another OS while Colima is using it. Colima refuses to start a writable disk when macOS reports that the partition is mounted, but it cannot detect every external writer.
+
+## Example
+
+```yaml
+physicalDisks:
+  - name: src
+    device: /dev/disk0s6
+    rawDevice: /dev/rdisk0s6
+    fsType: ext4
+    writable: true
+    mountPoint: /mnt/colima/physical/src
+    backend: nbd
+    hostAccess:
+      enabled: true
+      driver: nfs
+      mountPoint: /Volumes/Colima/src
+```
+
+Start or restart Colima after editing the profile config:
+
+```sh
+colima start --edit
+colima restart
+```
+
+The disk is mounted in the VM at `mountPoint`. When `hostAccess.enabled` is true, Colima also mounts the VM export on macOS at `hostAccess.mountPoint`.
+
+Colima uses `sudo` on macOS only for operations that require host root privileges: opening the raw partition through `qemu-nbd`, mounting the NFS export on macOS, and cleaning those resources up. Guest setup also uses `sudo` inside the VM to connect `/dev/nbdN`, mount the filesystem, and manage the NFS export.
+
+## Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | yes | Stable disk name. Use letters, numbers, `.`, `_`, or `-`. |
+| `device` | yes | macOS partition device, for example `/dev/disk0s6`. Whole disks are rejected. |
+| `rawDevice` | no | Raw device path. Defaults from `device`, for example `/dev/rdisk0s6`. |
+| `fsType` | no | `auto`, `ext4`, `xfs`, or `btrfs`. Defaults to `auto`. |
+| `writable` | no | Mount read-write when true. Defaults to read-only. |
+| `mountPoint` | no | VM mount point. Defaults to `/mnt/colima/physical/<name>`. |
+| `backend` | no | `auto` or `nbd`. Defaults to `auto`, currently resolved to `nbd`. |
+| `hostAccess.enabled` | no | Mount the VM filesystem back on macOS. |
+| `hostAccess.driver` | no | `nfs`. |
+| `hostAccess.mountPoint` | no | macOS mount point. Defaults to `/Volumes/Colima/<name>`. |
+
+When `hostAccess.enabled` is true, keep `mountPoint` under `/mnt/colima/physical`. Colima exports `/mnt/colima/physical` as the NFSv4 pseudo-root and mounts the disk on macOS as `localhost:/<name>`.
+
+## How It Works
+
+Colima uses `qemu-nbd` on macOS to expose the raw partition to the VM. The NBD service is bound to `127.0.0.1` and is reachable from the VM through an SSH reverse tunnel, not through the LAN.
+
+Inside the VM, Colima connects the export to `/dev/nbdN`, verifies the filesystem type with `blkid`, and mounts it at `mountPoint`.
+
+When host access is enabled, Colima starts an NFS server in the VM and mounts it on macOS through an SSH local tunnel. macOS sees an NFS mount; the Linux VM remains the only machine mounting the physical filesystem directly.
+
+## Troubleshooting
+
+Check the partition identity on macOS:
+
+```sh
+diskutil info /dev/disk0s6
+```
+
+Check the mounted filesystem in the VM:
+
+```sh
+colima ssh -- findmnt /mnt/colima/physical/src
+colima ssh -- blkid /dev/nbd0
+```
+
+If Colima reports that a writable disk is mounted on macOS, unmount it first:
+
+```sh
+diskutil unmount /dev/disk0s6
+```
+
+If host access remains mounted after an interrupted shutdown:
+
+```sh
+sudo umount /Volumes/Colima/src
+colima stop --force
+```
+
+## Limitations
+
+- Physical disks are currently macOS-only.
+- The implemented backend is NBD. Native VZ block device attachment can be added later without changing the `physicalDisks` user-facing schema.
+- Writable mode requires the filesystem to be mounted by Colima only.
+- Host access requires the macOS NFS client and the VM NFS server.

--- a/docs/PHYSICAL_DISKS.md
+++ b/docs/PHYSICAL_DISKS.md
@@ -104,6 +104,18 @@ rm etc_sudoers.d_lima
 
 For read-only configurations, Colima mounts the filesystem read-only in the guest. The current Lima VZ block-device contract does not provide a host-enforced read-only flag, so use `backend: nbd` if host-enforced read-only block access is required.
 
+## E2E Smoke Test
+
+Contributors can run the native VZ physical disk smoke test on macOS with a Lima build that supports secure block devices:
+
+```sh
+COLIMA_BINARY=/path/to/colima \
+LIMA_BIN=/path/to/secure-lima/limactl \
+scripts/physical_disk_vz_e2e.sh
+```
+
+The script creates a temporary ext4 disk image, attaches it as a macOS disk image, installs a temporary root-owned Lima helper under `/opt/colima-vz-e2e`, starts a disposable Colima profile with `backend: vz`, verifies guest and host read/write through the NFS host-access path, and removes the VM, disk image, helper, and sudoers fragment during cleanup.
+
 ## Host Access
 
 When host access is enabled, Colima starts an NFS server in the VM and mounts it on macOS through an SSH local tunnel. macOS sees an NFS mount; the Linux VM remains the only machine mounting the physical filesystem directly.

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -259,6 +259,30 @@ sshPort: 0
 # Default: []
 mounts: []
 
+# Mount host physical disk partitions inside the VM and optionally expose them
+# back to macOS through NFS.
+#
+# WARNING: writable physical disks can corrupt data if the same filesystem is
+# mounted by macOS or another OS at the same time. Colima refuses to start when
+# a writable disk is already mounted on macOS, but it cannot detect every
+# external writer.
+#
+# EXAMPLE - writable ext4 partition with macOS access via NFS:
+# physicalDisks:
+#   - name: src
+#     device: /dev/disk0s6
+#     rawDevice: /dev/rdisk0s6
+#     fsType: ext4 # ext4, xfs, btrfs, or auto
+#     writable: true
+#     mountPoint: /mnt/colima/physical/src
+#     hostAccess:
+#       enabled: true
+#       driver: nfs
+#       mountPoint: /Volumes/Colima/src
+#
+# Default: []
+physicalDisks: []
+
 # Specify a custom disk image for the virtual machine.
 # When not specified, Colima downloads an appropriate disk image from Github at
 # https://github.com/abiosoft/colima-core/releases.

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -275,10 +275,15 @@ mounts: []
 #     fsType: ext4 # ext4, xfs, btrfs, or auto
 #     writable: true
 #     mountPoint: /mnt/colima/physical/src
+#     backend: nbd # auto, nbd, or vz
 #     hostAccess:
 #       enabled: true
 #       driver: nfs
 #       mountPoint: /Volumes/Colima/src
+#
+# Use backend: vz with vmType: vz for native Virtualization.Framework block
+# attachment. This requires a Lima build that exposes `limactl sudoers
+# --block-device`; host access still uses NFS.
 #
 # Default: []
 physicalDisks: []

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -97,6 +97,10 @@ func (l *limaVM) Start(ctx context.Context, conf config.Config) error {
 		return err
 	})
 
+	a.Add(func() error {
+		return l.assertPhysicalDiskBackends(conf)
+	})
+
 	a.Add(l.assertQemu)
 
 	a.Add(func() error {
@@ -151,6 +155,10 @@ func (l *limaVM) resume(ctx context.Context, conf config.Config) error {
 
 		l.limaConf, err = newConf(ctx, conf)
 		return err
+	})
+
+	a.Add(func() error {
+		return l.assertPhysicalDiskBackends(conf)
 	})
 
 	a.Add(l.assertQemu)

--- a/environment/vm/lima/lima.go
+++ b/environment/vm/lima/lima.go
@@ -208,8 +208,15 @@ func (l limaVM) Stop(ctx context.Context, force bool) error {
 
 	a.Stage("stopping")
 
+	conf, _ := configmanager.LoadInstance()
+	a.Add(func() error {
+		if err := l.stopPhysicalDisks(ctx, conf); err != nil {
+			log.Warnln(fmt.Errorf("error stopping physical disks: %w", err))
+		}
+		return nil
+	})
+
 	if util.MacOS() {
-		conf, _ := configmanager.LoadInstance()
 		a.Retry("", time.Second*1, 10, func(retryCount int) error {
 			err := l.daemon.Stop(ctx, conf)
 			if err != nil {
@@ -235,9 +242,16 @@ func (l limaVM) Stop(ctx context.Context, force bool) error {
 
 func (l limaVM) Teardown(ctx context.Context) error {
 	a := l.Init(ctx)
+	conf, _ := configmanager.LoadInstance()
+
+	a.Add(func() error {
+		if err := l.stopPhysicalDisks(ctx, conf); err != nil {
+			l.Logger(ctx).Warnln(fmt.Errorf("error stopping physical disks: %w", err))
+		}
+		return nil
+	})
 
 	if util.MacOS() {
-		conf, _ := configmanager.LoadInstance()
 		a.Retry("", time.Second*1, 10, func(retryCount int) error {
 			return l.daemon.Stop(ctx, conf)
 		})
@@ -350,6 +364,14 @@ func (l *limaVM) addPostStartActions(a *cli.ActiveCommandChain, conf config.Conf
 	a.Add(func() error {
 		if err := configmanager.SaveToFile(conf, config.CurrentProfile().StateFile()); err != nil {
 			logrus.Warnln(fmt.Errorf("error persisting Colima state: %w", err))
+		}
+		return nil
+	})
+
+	// attach physical block devices and mount optional host access.
+	a.Add(func() error {
+		if err := l.setupPhysicalDisks(context.Background(), conf); err != nil {
+			return fmt.Errorf("error setting up physical disks: %w", err)
 		}
 		return nil
 	})

--- a/environment/vm/lima/limaconfig/config.go
+++ b/environment/vm/lima/limaconfig/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Memory               string            `yaml:"memory,omitempty"`
 	Disk                 string            `yaml:"disk,omitempty"`
 	AdditionalDisks      []Disk            `yaml:"additionalDisks,omitempty" json:"additionalDisks,omitempty"`
+	BlockDevices         []string          `yaml:"blockDevices,omitempty" json:"blockDevices,omitempty"`
 	Mounts               []Mount           `yaml:"mounts,omitempty"`
 	MountType            MountType         `yaml:"mountType,omitempty" json:"mountType,omitempty"`
 	SSH                  SSH               `yaml:"ssh"`

--- a/environment/vm/lima/physical_disk.go
+++ b/environment/vm/lima/physical_disk.go
@@ -370,6 +370,9 @@ func (l *limaVM) attachPhysicalDiskInGuest(disk physicalDiskRuntime, guestDevice
 }
 
 func (l *limaVM) startPhysicalDiskNFSTunnel(disk physicalDiskRuntime) error {
+	if err := os.MkdirAll(disk.stateDir, 0755); err != nil {
+		return err
+	}
 	port, err := freeTCPPort()
 	if err != nil {
 		return err

--- a/environment/vm/lima/physical_disk.go
+++ b/environment/vm/lima/physical_disk.go
@@ -1,0 +1,667 @@
+package lima
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/util"
+)
+
+//go:embed physical_disk.sh
+var physicalDiskScript string
+
+const (
+	physicalDiskGuestNBDPortBase = 10809
+	physicalDiskNFSPort          = 2049
+	physicalDiskNFSRoot          = "/mnt/colima/physical"
+)
+
+type physicalDiskRuntime struct {
+	config.PhysicalDisk
+
+	index        int
+	nbdDevice    string
+	nbdGuestPort int
+	nbdHostPort  int
+	nfsHostPort  int
+	stateDir     string
+}
+
+func (l *limaVM) setupPhysicalDisks(ctx context.Context, conf config.Config) error {
+	if len(conf.PhysicalDisks) == 0 {
+		return nil
+	}
+	if !util.MacOS() {
+		return fmt.Errorf("physical disks are only supported on macOS")
+	}
+	if err := util.AssertQemuNBD(); err != nil {
+		return err
+	}
+	for i, disk := range conf.PhysicalDisks {
+		runtime, err := newPhysicalDiskRuntime(i, disk)
+		if err != nil {
+			return err
+		}
+
+		if err := l.setupPhysicalDisk(ctx, runtime); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *limaVM) setupPhysicalDisk(ctx context.Context, disk physicalDiskRuntime) error {
+	// Clear stale state from a previous interrupted startup.
+	if err := l.stopPhysicalDisk(ctx, disk); err != nil {
+		l.Logger(ctx).Warnln(fmt.Errorf("error cleaning up physical disk %s: %w", disk.Name, err))
+	}
+
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = l.stopPhysicalDisk(ctx, disk)
+		}
+	}()
+
+	if err := l.assertPhysicalDiskReady(disk); err != nil {
+		return fmt.Errorf("physical disk %s is not ready: %w", disk.Name, err)
+	}
+	if err := l.startPhysicalDiskNBD(disk); err != nil {
+		return fmt.Errorf("error starting physical disk %s NBD backend: %w", disk.Name, err)
+	}
+	if err := l.startPhysicalDiskNBDTunnel(disk); err != nil {
+		return fmt.Errorf("error starting physical disk %s NBD tunnel: %w", disk.Name, err)
+	}
+	if err := l.attachPhysicalDiskInGuest(disk); err != nil {
+		return fmt.Errorf("error attaching physical disk %s in VM: %w", disk.Name, err)
+	}
+	if err := l.assertPhysicalDiskBackendLive(disk); err != nil {
+		return fmt.Errorf("error checking physical disk %s backend health: %w", disk.Name, err)
+	}
+	if disk.HostAccess.Enabled {
+		if err := l.startPhysicalDiskNFSTunnel(disk); err != nil {
+			return fmt.Errorf("error starting physical disk %s NFS tunnel: %w", disk.Name, err)
+		}
+		if err := l.mountPhysicalDiskOnHost(disk); err != nil {
+			return fmt.Errorf("error mounting physical disk %s on host: %w", disk.Name, err)
+		}
+		if err := l.assertPhysicalDiskHostAccessLive(disk); err != nil {
+			return fmt.Errorf("error checking physical disk %s host access health: %w", disk.Name, err)
+		}
+	}
+
+	cleanup = false
+	return nil
+}
+
+func (l *limaVM) stopPhysicalDisks(ctx context.Context, conf config.Config) error {
+	var errs []string
+	for i, disk := range conf.PhysicalDisks {
+		runtime, err := newPhysicalDiskRuntime(i, disk)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		if err := l.stopPhysicalDisk(ctx, runtime); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", runtime.Name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func newPhysicalDiskRuntime(index int, disk config.PhysicalDisk) (physicalDiskRuntime, error) {
+	if disk.RawDevice == "" {
+		disk.RawDevice = strings.Replace(disk.Device, "/dev/disk", "/dev/rdisk", 1)
+	}
+	if disk.FSType == "" {
+		disk.FSType = "auto"
+	}
+	if disk.Backend == "" || disk.Backend == "auto" {
+		disk.Backend = "nbd"
+	}
+	if disk.MountPoint == "" {
+		disk.MountPoint = filepath.Join("/mnt/colima/physical", disk.Name)
+	}
+	if disk.HostAccess.Enabled {
+		if disk.HostAccess.Driver == "" {
+			disk.HostAccess.Driver = "nfs"
+		}
+		if disk.HostAccess.MountPoint == "" {
+			disk.HostAccess.MountPoint = filepath.Join("/Volumes/Colima", disk.Name)
+		}
+		if _, err := physicalDiskNFSSourcePath(disk.MountPoint); err != nil {
+			return physicalDiskRuntime{}, err
+		}
+	}
+
+	if disk.Backend != "nbd" {
+		return physicalDiskRuntime{}, fmt.Errorf("unsupported physical disk backend %q", disk.Backend)
+	}
+
+	stateDir := filepath.Join(config.CurrentProfile().ConfigDir(), "physical-disks", disk.Name)
+	return physicalDiskRuntime{
+		PhysicalDisk: disk,
+		index:        index,
+		nbdDevice:    fmt.Sprintf("/dev/nbd%d", index),
+		nbdGuestPort: physicalDiskGuestNBDPortBase + index,
+		stateDir:     stateDir,
+	}, nil
+}
+
+func (l *limaVM) assertPhysicalDiskReady(disk physicalDiskRuntime) error {
+	if _, err := os.Stat(disk.RawDevice); err != nil {
+		return fmt.Errorf("rawDevice %s is not accessible: %w", disk.RawDevice, err)
+	}
+	out, err := l.host.RunOutput("diskutil", "info", disk.Device)
+	if err != nil {
+		return err
+	}
+	if disk.Writable && diskutilMounted(out) {
+		return fmt.Errorf("%s is mounted on macOS; unmount it before using writable physicalDisks", disk.Device)
+	}
+	return nil
+}
+
+func diskutilMounted(out string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Mounted:") {
+			return strings.Contains(line, "Yes")
+		}
+	}
+	return false
+}
+
+func (l *limaVM) startPhysicalDiskNBD(disk physicalDiskRuntime) error {
+	if err := os.MkdirAll(disk.stateDir, 0755); err != nil {
+		return err
+	}
+	qemuNBD, err := exec.LookPath("qemu-nbd")
+	if err != nil {
+		return err
+	}
+	port, err := freeTCPPort()
+	if err != nil {
+		return err
+	}
+	disk.nbdHostPort = port
+	if err := os.WriteFile(disk.nbdHostPortFile(), []byte(fmt.Sprint(port)), 0644); err != nil {
+		return err
+	}
+
+	args := []string{
+		qemuNBD,
+		"--fork",
+		"--persistent",
+		"--format=raw",
+		"--cache=none",
+		"--bind=127.0.0.1",
+		fmt.Sprintf("--port=%d", port),
+		"--pid-file", disk.qemuPidFile(),
+		disk.RawDevice,
+	}
+
+	if !disk.Writable {
+		args = append(args[:1], append([]string{"--read-only"}, args[1:]...)...)
+	}
+
+	logFile := disk.qemuLogFile()
+	cmd := strings.Join([]string{
+		"set -eu",
+		fmt.Sprintf("raw_device=%s", shellQuote(disk.RawDevice)),
+		fmt.Sprintf("qemu_nbd=%s", shellQuote(qemuNBD)),
+		"ps axww -o pid= -o command= | awk -v raw=\"$raw_device\" -v qemu=\"$qemu_nbd\" '{ pid=$1; $1=\"\"; sub(/^ +/, \"\"); if (index($0, qemu) == 1 && index($0, raw)) print pid }' | while read -r pid; do kill \"$pid\" >/dev/null 2>&1 || true; done",
+		shellJoin(args) + " >" + shellQuote(logFile) + " 2>&1",
+		fmt.Sprintf("chown %d:%d %s %s >/dev/null 2>&1 || true", os.Getuid(), os.Getgid(), shellQuote(disk.qemuPidFile()), shellQuote(logFile)),
+		"chmod 0644 " + shellQuote(disk.qemuPidFile()) + " " + shellQuote(logFile) + " >/dev/null 2>&1 || true",
+	}, "\n")
+	if err := l.host.RunInteractive("sudo", "sh", "-c", cmd); err != nil {
+		return appendPhysicalDiskLog(err, logFile, "qemu-nbd")
+	}
+	if err := l.waitTCPListen(port); err != nil {
+		return appendPhysicalDiskLog(err, logFile, "qemu-nbd")
+	}
+	return nil
+}
+
+func (l *limaVM) startPhysicalDiskNBDTunnel(disk physicalDiskRuntime) error {
+	port, err := readPort(disk.nbdHostPortFile())
+	if err != nil {
+		return err
+	}
+	disk.nbdHostPort = port
+
+	target := fmt.Sprintf("127.0.0.1:%d:127.0.0.1:%d", disk.nbdGuestPort, disk.nbdHostPort)
+	if err := l.startSSHForward(disk.nbdTunnelPidFile(), disk.nbdTunnelLogFile(), "-R", target); err != nil {
+		return err
+	}
+	if err := l.waitHostPID(disk.nbdTunnelPidFile()); err != nil {
+		return appendPhysicalDiskLog(err, disk.nbdTunnelLogFile(), "NBD SSH tunnel")
+	}
+	return nil
+}
+
+func (l *limaVM) attachPhysicalDiskInGuest(disk physicalDiskRuntime) error {
+	writable := "false"
+	if disk.Writable {
+		writable = "true"
+	}
+	return l.runGuestWith(strings.NewReader(physicalDiskScript),
+		"sudo", "sh", "-s", "--",
+		disk.Name,
+		disk.nbdDevice,
+		fmt.Sprint(disk.nbdGuestPort),
+		disk.MountPoint,
+		disk.FSType,
+		writable,
+	)
+}
+
+func (l *limaVM) startPhysicalDiskNFSTunnel(disk physicalDiskRuntime) error {
+	port, err := freeTCPPort()
+	if err != nil {
+		return err
+	}
+	disk.nfsHostPort = port
+	if err := os.WriteFile(disk.nfsHostPortFile(), []byte(fmt.Sprint(port)), 0644); err != nil {
+		return err
+	}
+
+	target := fmt.Sprintf("127.0.0.1:%d:127.0.0.1:%d", port, physicalDiskNFSPort)
+	if err := l.startSSHForward(disk.nfsTunnelPidFile(), disk.nfsTunnelLogFile(), "-L", target); err != nil {
+		return err
+	}
+	if err := l.waitHostPID(disk.nfsTunnelPidFile()); err != nil {
+		return appendPhysicalDiskLog(err, disk.nfsTunnelLogFile(), "NFS SSH tunnel")
+	}
+	if err := l.waitTCPListen(port); err != nil {
+		return appendPhysicalDiskLog(err, disk.nfsTunnelLogFile(), "NFS SSH tunnel")
+	}
+	return nil
+}
+
+func (l *limaVM) mountPhysicalDiskOnHost(disk physicalDiskRuntime) error {
+	port, err := readPort(disk.nfsHostPortFile())
+	if err != nil {
+		return err
+	}
+	disk.nfsHostPort = port
+
+	if err := os.MkdirAll(disk.HostAccess.MountPoint, 0755); err != nil {
+		if err := l.host.RunInteractive("sudo", "mkdir", "-p", disk.HostAccess.MountPoint); err != nil {
+			return err
+		}
+	}
+	if hostMountpointMounted(l, disk.HostAccess.MountPoint) {
+		return nil
+	}
+
+	sourcePath, err := disk.nfsSourcePath()
+	if err != nil {
+		return err
+	}
+
+	opts := fmt.Sprintf("vers=4,tcp,nocallback,sec=sys,resvport,port=%d", disk.nfsHostPort)
+	source := "localhost:" + sourcePath
+	var lastErr error
+	for i := 0; i < 10; i++ {
+		if lastErr = l.host.RunInteractive("sudo", "mount", "-t", "nfs", "-o", opts, source, disk.HostAccess.MountPoint); lastErr == nil {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return lastErr
+}
+
+func (l *limaVM) stopPhysicalDisk(ctx context.Context, disk physicalDiskRuntime) error {
+	var errs []string
+
+	if disk.HostAccess.Enabled {
+		if err := l.unmountPhysicalDiskOnHost(disk); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if err := l.killHostPID(disk.nfsTunnelPidFile(), false); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if l.Running(ctx) {
+		if err := l.detachPhysicalDiskInGuest(disk); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if err := l.killHostPID(disk.nbdTunnelPidFile(), false); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := l.killPhysicalDiskNBD(disk); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (l *limaVM) detachPhysicalDiskInGuest(disk physicalDiskRuntime) error {
+	script := strings.Join([]string{
+		"set -eu",
+		fmt.Sprintf("export_file=%s", shellQuote(filepath.Join("/etc/exports.d", "colima-physical-"+disk.Name+".exports"))),
+		fmt.Sprintf("export_root_file=%s", shellQuote(filepath.Join("/etc/exports.d", "colima-physical-root.exports"))),
+		fmt.Sprintf("mount_point=%s", shellQuote(disk.MountPoint)),
+		fmt.Sprintf("nbd_device=%s", shellQuote(disk.nbdDevice)),
+		"rm -f \"$export_file\"",
+		"if ! find /etc/exports.d -name 'colima-physical-*.exports' ! -name 'colima-physical-root.exports' | grep -q .; then rm -f \"$export_root_file\"; fi",
+		"exportfs -ra >/dev/null 2>&1 || true",
+		"if findmnt --noheadings --mountpoint \"$mount_point\" >/dev/null 2>&1; then umount \"$mount_point\" >/dev/null 2>&1 || true; fi",
+		"if nbd-client -c \"$nbd_device\" >/dev/null 2>&1; then nbd-client -d \"$nbd_device\" >/dev/null 2>&1 || true; fi",
+	}, "\n")
+	return l.runGuestQuiet("sudo", "sh", "-c", script)
+}
+
+func (l *limaVM) unmountPhysicalDiskOnHost(disk physicalDiskRuntime) error {
+	if !hostMountpointMounted(l, disk.HostAccess.MountPoint) {
+		return nil
+	}
+	if err := l.host.RunQuiet("sudo", "-n", "umount", disk.HostAccess.MountPoint); err == nil {
+		return nil
+	}
+	return l.host.RunInteractive("sudo", "umount", disk.HostAccess.MountPoint)
+}
+
+func hostMountpointMounted(l *limaVM, mountPoint string) bool {
+	cmd := "mount | grep -F " + shellQuote(" on "+mountPoint+" ") + " >/dev/null"
+	return l.host.RunQuiet("sh", "-c", cmd) == nil
+}
+
+func (l *limaVM) assertPhysicalDiskBackendLive(disk physicalDiskRuntime) error {
+	if err := l.waitPIDExists(disk.qemuPidFile()); err != nil {
+		return appendPhysicalDiskLog(err, disk.qemuLogFile(), "qemu-nbd")
+	}
+	if err := l.waitHostPID(disk.nbdTunnelPidFile()); err != nil {
+		return appendPhysicalDiskLog(err, disk.nbdTunnelLogFile(), "NBD SSH tunnel")
+	}
+	port, err := readPort(disk.nbdHostPortFile())
+	if err != nil {
+		return err
+	}
+	if err := l.waitTCPListen(port); err != nil {
+		return appendPhysicalDiskLog(err, disk.qemuLogFile(), "qemu-nbd")
+	}
+	return nil
+}
+
+func (l *limaVM) assertPhysicalDiskHostAccessLive(disk physicalDiskRuntime) error {
+	if err := l.waitHostPID(disk.nfsTunnelPidFile()); err != nil {
+		return appendPhysicalDiskLog(err, disk.nfsTunnelLogFile(), "NFS SSH tunnel")
+	}
+	port, err := readPort(disk.nfsHostPortFile())
+	if err != nil {
+		return err
+	}
+	if err := l.waitTCPListen(port); err != nil {
+		return appendPhysicalDiskLog(err, disk.nfsTunnelLogFile(), "NFS SSH tunnel")
+	}
+	if !hostMountpointMounted(l, disk.HostAccess.MountPoint) {
+		return fmt.Errorf("%s is not mounted on host", disk.HostAccess.MountPoint)
+	}
+	return nil
+}
+
+func (l *limaVM) startSSHForward(pidFile, logFile string, forwardArgs ...string) error {
+	if err := os.MkdirAll(filepath.Dir(pidFile), 0755); err != nil {
+		return err
+	}
+	_ = os.Remove(pidFile)
+	_ = os.Remove(logFile)
+	sshConfig := filepath.Join(config.CurrentProfile().LimaInstanceDir(), "ssh.config")
+	target := "lima-" + config.CurrentProfile().ID
+	forwardTarget := ""
+	if len(forwardArgs) > 0 {
+		forwardTarget = forwardArgs[len(forwardArgs)-1]
+	}
+	args := []string{
+		"ssh",
+		"-F", sshConfig,
+		"-o", "ControlMaster=no",
+		"-o", "ControlPath=none",
+		"-o", "ExitOnForwardFailure=yes",
+		"-o", "ServerAliveInterval=15",
+		"-o", "ServerAliveCountMax=2",
+		"-f",
+		"-N",
+	}
+	args = append(args, forwardArgs...)
+	args = append(args, target)
+
+	cmd := strings.Join([]string{
+		shellJoin(args) + " >" + shellQuote(logFile) + " 2>&1",
+		"ps axww -o pid= -o command= | awk -v fwd=" + shellQuote(forwardTarget) + " -v target=" + shellQuote(target) + " '{ pid=$1; $1=\"\"; sub(/^ +/, \"\"); if ($0 ~ /^([^ ]*\\/)?ssh[[:space:]]/ && index($0, fwd) && index($0, target)) {print pid; exit} }' > " + shellQuote(pidFile),
+		"test -s " + shellQuote(pidFile),
+	}, "\n")
+	return l.host.RunQuiet("sh", "-c", cmd)
+}
+
+func (l *limaVM) waitHostPID(pidFile string) error {
+	cmd := "test -s " + shellQuote(pidFile) + " && kill -0 $(cat " + shellQuote(pidFile) + ")"
+	var err error
+	for i := 0; i < 20; i++ {
+		if err = l.host.RunQuiet("sh", "-c", cmd); err == nil {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return err
+}
+
+func (l *limaVM) waitPIDExists(pidFile string) error {
+	cmd := "test -s " + shellQuote(pidFile) + " && ps -p $(cat " + shellQuote(pidFile) + ") >/dev/null"
+	var err error
+	for i := 0; i < 20; i++ {
+		if err = l.host.RunQuiet("sh", "-c", cmd); err == nil {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return err
+}
+
+func (l *limaVM) killHostPID(pidFile string, sudo bool) error {
+	if _, err := os.Stat(pidFile); err != nil {
+		return nil
+	}
+	if sudo {
+		cmd := "if [ -s " + shellQuote(pidFile) + " ]; then kill $(cat " + shellQuote(pidFile) + ") >/dev/null 2>&1 || true; fi; rm -f " + shellQuote(pidFile)
+		return l.host.RunInteractive("sudo", "sh", "-c", cmd)
+	}
+	cmd := "if [ -s " + shellQuote(pidFile) + " ]; then kill $(cat " + shellQuote(pidFile) + ") >/dev/null 2>&1 || true; fi; rm -f " + shellQuote(pidFile)
+	return l.host.RunQuiet("sh", "-c", cmd)
+}
+
+func (l *limaVM) killPhysicalDiskNBD(disk physicalDiskRuntime) error {
+	port, _ := readPort(disk.nbdHostPortFile())
+	script := strings.Join([]string{
+		"set +e",
+		fmt.Sprintf("pid_file=%s", shellQuote(disk.qemuPidFile())),
+		fmt.Sprintf("port=%s", shellQuote(fmt.Sprint(port))),
+		"pids=",
+		"if [ -s \"$pid_file\" ]; then pids=\"$pids $(cat \"$pid_file\")\"; fi",
+		"if [ \"$port\" != \"0\" ] && command -v lsof >/dev/null 2>&1; then",
+		"  pids=\"$pids $(lsof -tiTCP:\"$port\" -sTCP:LISTEN 2>/dev/null)\"",
+		"fi",
+		"if [ -n \"$pids\" ]; then kill $pids >/dev/null 2>&1 || true; fi",
+		"alive=",
+		"for pid in $pids; do ps -p \"$pid\" >/dev/null 2>&1 && alive=\"$alive $pid\"; done",
+		"if [ -n \"$alive\" ]; then sudo -n kill $alive >/dev/null 2>&1 || true; fi",
+		"rm -f \"$pid_file\"",
+	}, "\n")
+	if err := l.host.RunQuiet("sh", "-c", script); err != nil {
+		return err
+	}
+	if !l.physicalDiskNBDRunning(disk) {
+		return nil
+	}
+
+	qemuNBD, err := exec.LookPath("qemu-nbd")
+	if err != nil {
+		qemuNBD = "qemu-nbd"
+	}
+	rootScript := strings.Join([]string{
+		"set +e",
+		fmt.Sprintf("raw_device=%s", shellQuote(disk.RawDevice)),
+		fmt.Sprintf("qemu_nbd=%s", shellQuote(qemuNBD)),
+		fmt.Sprintf("pid_file=%s", shellQuote(disk.qemuPidFile())),
+		"if [ -s \"$pid_file\" ]; then kill $(cat \"$pid_file\") >/dev/null 2>&1 || true; fi",
+		"ps axww -o pid= -o command= | awk -v raw=\"$raw_device\" -v qemu=\"$qemu_nbd\" '{ pid=$1; $1=\"\"; sub(/^ +/, \"\"); if (index($0, qemu) == 1 && index($0, raw)) print pid }' | while read -r pid; do kill \"$pid\" >/dev/null 2>&1 || true; done",
+		"rm -f \"$pid_file\"",
+	}, "\n")
+	if err := l.host.RunInteractive("sudo", "sh", "-c", rootScript); err != nil {
+		return err
+	}
+	if l.physicalDiskNBDRunning(disk) {
+		return fmt.Errorf("qemu-nbd for %s is still running", disk.RawDevice)
+	}
+	return nil
+}
+
+func (l *limaVM) runGuestQuiet(args ...string) error {
+	args = append([]string{limactl, "shell", "--workdir", "/", config.CurrentProfile().ID}, args...)
+	return l.host.RunQuiet(args...)
+}
+
+func (l *limaVM) runGuestWith(stdin io.Reader, args ...string) error {
+	args = append([]string{limactl, "shell", "--workdir", "/", config.CurrentProfile().ID}, args...)
+	return l.host.RunWith(stdin, nil, args...)
+}
+
+func freeTCPPort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer ln.Close()
+
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected tcp listener address: %s", ln.Addr())
+	}
+	return addr.Port, nil
+}
+
+func readPort(file string) (int, error) {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return 0, err
+	}
+	var port int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(b)), "%d", &port); err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+func (p physicalDiskRuntime) nfsSourcePath() (string, error) {
+	return physicalDiskNFSSourcePath(p.MountPoint)
+}
+
+func physicalDiskNFSSourcePath(mountPoint string) (string, error) {
+	rel, err := filepath.Rel(physicalDiskNFSRoot, mountPoint)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("NFS host access requires mountPoint under %s", physicalDiskNFSRoot)
+	}
+	return "/" + filepath.ToSlash(rel), nil
+}
+
+func (l *limaVM) waitTCPListen(port int) error {
+	var err error
+	for i := 0; i < 40; i++ {
+		if err = l.host.RunQuiet("sh", "-c", tcpListenCmd(port)); err == nil {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return err
+}
+
+func (l *limaVM) physicalDiskNBDRunning(disk physicalDiskRuntime) bool {
+	if l.host.RunQuiet("sh", "-c", "test -s "+shellQuote(disk.qemuPidFile())+" && ps -p $(cat "+shellQuote(disk.qemuPidFile())+") >/dev/null") == nil {
+		return true
+	}
+	port, err := readPort(disk.nbdHostPortFile())
+	if err != nil || port == 0 {
+		return false
+	}
+	return l.host.RunQuiet("sh", "-c", tcpListenCmd(port)) == nil
+}
+
+func tcpListenCmd(port int) string {
+	return fmt.Sprintf("netstat -an -p tcp | awk '$4 ~ /[.:]%d$/ && $6 == \"LISTEN\" {found=1} END{exit !found}'", port)
+}
+
+func appendPhysicalDiskLog(err error, logFile, name string) error {
+	b, readErr := os.ReadFile(logFile)
+	if readErr != nil {
+		return err
+	}
+
+	log := strings.TrimSpace(string(b))
+	if log == "" {
+		return err
+	}
+	const maxLogLen = 4096
+	if len(log) > maxLogLen {
+		log = log[:maxLogLen] + "\n..."
+	}
+	return fmt.Errorf("%w: %s log:\n%s", err, name, log)
+}
+
+func shellJoin(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = shellQuote(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+func (p physicalDiskRuntime) qemuPidFile() string { return filepath.Join(p.stateDir, "qemu-nbd.pid") }
+func (p physicalDiskRuntime) qemuLogFile() string { return filepath.Join(p.stateDir, "qemu-nbd.log") }
+func (p physicalDiskRuntime) nbdTunnelPidFile() string {
+	return filepath.Join(p.stateDir, "nbd-ssh.pid")
+}
+func (p physicalDiskRuntime) nbdTunnelLogFile() string {
+	return filepath.Join(p.stateDir, "nbd-ssh.log")
+}
+func (p physicalDiskRuntime) nfsTunnelPidFile() string {
+	return filepath.Join(p.stateDir, "nfs-ssh.pid")
+}
+func (p physicalDiskRuntime) nfsTunnelLogFile() string {
+	return filepath.Join(p.stateDir, "nfs-ssh.log")
+}
+func (p physicalDiskRuntime) nbdHostPortFile() string {
+	return filepath.Join(p.stateDir, "nbd-host.port")
+}
+func (p physicalDiskRuntime) nfsHostPortFile() string {
+	return filepath.Join(p.stateDir, "nfs-host.port")
+}

--- a/environment/vm/lima/physical_disk.go
+++ b/environment/vm/lima/physical_disk.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/environment/vm/lima/limaconfig"
 	"github.com/abiosoft/colima/util"
 )
 
@@ -31,6 +32,7 @@ type physicalDiskRuntime struct {
 
 	index        int
 	nbdDevice    string
+	guestDevice  string
 	nbdGuestPort int
 	nbdHostPort  int
 	nfsHostPort  int
@@ -44,21 +46,59 @@ func (l *limaVM) setupPhysicalDisks(ctx context.Context, conf config.Config) err
 	if !util.MacOS() {
 		return fmt.Errorf("physical disks are only supported on macOS")
 	}
-	if err := util.AssertQemuNBD(); err != nil {
-		return err
-	}
+
+	var runtimes []physicalDiskRuntime
+	requiresNBD := false
 	for i, disk := range conf.PhysicalDisks {
 		runtime, err := newPhysicalDiskRuntime(i, disk)
 		if err != nil {
 			return err
 		}
+		runtimes = append(runtimes, runtime)
+		if runtime.Backend == "nbd" {
+			requiresNBD = true
+		}
+	}
 
-		if err := l.setupPhysicalDisk(ctx, runtime); err != nil {
+	if requiresNBD {
+		if err := util.AssertQemuNBD(); err != nil {
 			return err
 		}
 	}
 
+	for _, runtime := range runtimes {
+		if err := l.setupPhysicalDisk(ctx, runtime); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func (l *limaVM) assertPhysicalDiskBackends(conf config.Config) error {
+	for _, disk := range conf.PhysicalDisks {
+		if physicalDiskBackend(disk) != "vz" {
+			continue
+		}
+		if l.limaConf.VMType != limaconfig.VZ {
+			return fmt.Errorf("physicalDisks.%s backend vz requires vmType: vz", disk.Name)
+		}
+		if !util.MacOS14OrNewer() {
+			return fmt.Errorf("physicalDisks.%s backend vz requires macOS 14 or newer", disk.Name)
+		}
+		if !l.limaSupportsSafeVZBlockDevices() {
+			return fmt.Errorf("physicalDisks.%s backend vz requires a Lima build with secure macOS VZ block-device support; expected limactl create --help and limactl sudoers --help to expose --block-device", disk.Name)
+		}
+	}
+	return nil
+}
+
+func (l *limaVM) limaSupportsSafeVZBlockDevices() bool {
+	createHelp, err := l.host.RunOutput(limactl, "create", "--help")
+	if err != nil || !strings.Contains(createHelp, "--block-device") {
+		return false
+	}
+	sudoersHelp, err := l.host.RunOutput(limactl, "sudoers", "--help")
+	return err == nil && strings.Contains(sudoersHelp, "--block-device")
 }
 
 func (l *limaVM) setupPhysicalDisk(ctx context.Context, disk physicalDiskRuntime) error {
@@ -77,14 +117,23 @@ func (l *limaVM) setupPhysicalDisk(ctx context.Context, disk physicalDiskRuntime
 	if err := l.assertPhysicalDiskReady(disk); err != nil {
 		return fmt.Errorf("physical disk %s is not ready: %w", disk.Name, err)
 	}
-	if err := l.startPhysicalDiskNBD(disk); err != nil {
-		return fmt.Errorf("error starting physical disk %s NBD backend: %w", disk.Name, err)
-	}
-	if err := l.startPhysicalDiskNBDTunnel(disk); err != nil {
-		return fmt.Errorf("error starting physical disk %s NBD tunnel: %w", disk.Name, err)
-	}
-	if err := l.attachPhysicalDiskInGuest(disk); err != nil {
-		return fmt.Errorf("error attaching physical disk %s in VM: %w", disk.Name, err)
+	switch disk.Backend {
+	case "nbd":
+		if err := l.startPhysicalDiskNBD(disk); err != nil {
+			return fmt.Errorf("error starting physical disk %s NBD backend: %w", disk.Name, err)
+		}
+		if err := l.startPhysicalDiskNBDTunnel(disk); err != nil {
+			return fmt.Errorf("error starting physical disk %s NBD tunnel: %w", disk.Name, err)
+		}
+		if err := l.attachPhysicalDiskInGuest(disk, disk.nbdDevice); err != nil {
+			return fmt.Errorf("error attaching physical disk %s in VM: %w", disk.Name, err)
+		}
+	case "vz":
+		if err := l.attachPhysicalDiskInGuest(disk, disk.guestDevice); err != nil {
+			return fmt.Errorf("error mounting physical disk %s in VM: %w", disk.Name, err)
+		}
+	default:
+		return fmt.Errorf("unsupported physical disk backend %q", disk.Backend)
 	}
 	if err := l.assertPhysicalDiskBackendLive(disk); err != nil {
 		return fmt.Errorf("error checking physical disk %s backend health: %w", disk.Name, err)
@@ -130,9 +179,7 @@ func newPhysicalDiskRuntime(index int, disk config.PhysicalDisk) (physicalDiskRu
 	if disk.FSType == "" {
 		disk.FSType = "auto"
 	}
-	if disk.Backend == "" || disk.Backend == "auto" {
-		disk.Backend = "nbd"
-	}
+	disk.Backend = physicalDiskBackend(disk)
 	if disk.MountPoint == "" {
 		disk.MountPoint = filepath.Join("/mnt/colima/physical", disk.Name)
 	}
@@ -148,7 +195,7 @@ func newPhysicalDiskRuntime(index int, disk config.PhysicalDisk) (physicalDiskRu
 		}
 	}
 
-	if disk.Backend != "nbd" {
+	if disk.Backend != "nbd" && disk.Backend != "vz" {
 		return physicalDiskRuntime{}, fmt.Errorf("unsupported physical disk backend %q", disk.Backend)
 	}
 
@@ -157,14 +204,63 @@ func newPhysicalDiskRuntime(index int, disk config.PhysicalDisk) (physicalDiskRu
 		PhysicalDisk: disk,
 		index:        index,
 		nbdDevice:    fmt.Sprintf("/dev/nbd%d", index),
+		guestDevice:  physicalDiskGuestDevice(disk),
 		nbdGuestPort: physicalDiskGuestNBDPortBase + index,
 		stateDir:     stateDir,
 	}, nil
 }
 
+func physicalDiskBackend(disk config.PhysicalDisk) string {
+	if disk.Backend == "" || disk.Backend == "auto" {
+		return "nbd"
+	}
+	return disk.Backend
+}
+
+func physicalDiskGuestDevice(disk config.PhysicalDisk) string {
+	if physicalDiskBackend(disk) != "vz" {
+		return ""
+	}
+	return filepath.Join("/dev/disk/by-id", "virtio-"+physicalDiskGuestBlockDeviceID(disk.Device))
+}
+
+func physicalDiskGuestBlockDeviceID(devicePath string) string {
+	base := filepath.Base(devicePath)
+	var b strings.Builder
+	b.Grow(len(base))
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	id := b.String()
+	if id == "" {
+		id = "block-device"
+	}
+	if len(id) > 20 {
+		id = id[:20]
+	}
+	return id
+}
+
 func (l *limaVM) assertPhysicalDiskReady(disk physicalDiskRuntime) error {
-	if _, err := os.Stat(disk.RawDevice); err != nil {
-		return fmt.Errorf("rawDevice %s is not accessible: %w", disk.RawDevice, err)
+	hostDevice := disk.RawDevice
+	hostDeviceField := "rawDevice"
+	if disk.Backend == "vz" {
+		hostDevice = disk.Device
+		hostDeviceField = "device"
+	}
+	if _, err := os.Stat(hostDevice); err != nil {
+		return fmt.Errorf("%s %s is not accessible: %w", hostDeviceField, hostDevice, err)
 	}
 	out, err := l.host.RunOutput("diskutil", "info", disk.Device)
 	if err != nil {
@@ -255,7 +351,7 @@ func (l *limaVM) startPhysicalDiskNBDTunnel(disk physicalDiskRuntime) error {
 	return nil
 }
 
-func (l *limaVM) attachPhysicalDiskInGuest(disk physicalDiskRuntime) error {
+func (l *limaVM) attachPhysicalDiskInGuest(disk physicalDiskRuntime, guestDevice string) error {
 	writable := "false"
 	if disk.Writable {
 		writable = "true"
@@ -263,11 +359,13 @@ func (l *limaVM) attachPhysicalDiskInGuest(disk physicalDiskRuntime) error {
 	return l.runGuestWith(strings.NewReader(physicalDiskScript),
 		"sudo", "sh", "-s", "--",
 		disk.Name,
-		disk.nbdDevice,
+		disk.Backend,
+		guestDevice,
 		fmt.Sprint(disk.nbdGuestPort),
 		disk.MountPoint,
 		disk.FSType,
 		writable,
+		fmt.Sprint(disk.HostAccess.Enabled),
 	)
 }
 
@@ -345,11 +443,13 @@ func (l *limaVM) stopPhysicalDisk(ctx context.Context, disk physicalDiskRuntime)
 		}
 	}
 
-	if err := l.killHostPID(disk.nbdTunnelPidFile(), false); err != nil {
-		errs = append(errs, err.Error())
-	}
-	if err := l.killPhysicalDiskNBD(disk); err != nil {
-		errs = append(errs, err.Error())
+	if disk.Backend == "nbd" {
+		if err := l.killHostPID(disk.nbdTunnelPidFile(), false); err != nil {
+			errs = append(errs, err.Error())
+		}
+		if err := l.killPhysicalDiskNBD(disk); err != nil {
+			errs = append(errs, err.Error())
+		}
 	}
 
 	if len(errs) > 0 {
@@ -359,18 +459,23 @@ func (l *limaVM) stopPhysicalDisk(ctx context.Context, disk physicalDiskRuntime)
 }
 
 func (l *limaVM) detachPhysicalDiskInGuest(disk physicalDiskRuntime) error {
-	script := strings.Join([]string{
+	lines := []string{
 		"set -eu",
 		fmt.Sprintf("export_file=%s", shellQuote(filepath.Join("/etc/exports.d", "colima-physical-"+disk.Name+".exports"))),
 		fmt.Sprintf("export_root_file=%s", shellQuote(filepath.Join("/etc/exports.d", "colima-physical-root.exports"))),
 		fmt.Sprintf("mount_point=%s", shellQuote(disk.MountPoint)),
-		fmt.Sprintf("nbd_device=%s", shellQuote(disk.nbdDevice)),
 		"rm -f \"$export_file\"",
 		"if ! find /etc/exports.d -name 'colima-physical-*.exports' ! -name 'colima-physical-root.exports' | grep -q .; then rm -f \"$export_root_file\"; fi",
 		"exportfs -ra >/dev/null 2>&1 || true",
 		"if findmnt --noheadings --mountpoint \"$mount_point\" >/dev/null 2>&1; then umount \"$mount_point\" >/dev/null 2>&1 || true; fi",
-		"if nbd-client -c \"$nbd_device\" >/dev/null 2>&1; then nbd-client -d \"$nbd_device\" >/dev/null 2>&1 || true; fi",
-	}, "\n")
+	}
+	if disk.Backend == "nbd" {
+		lines = append(lines,
+			fmt.Sprintf("nbd_device=%s", shellQuote(disk.nbdDevice)),
+			"if command -v nbd-client >/dev/null 2>&1 && nbd-client -c \"$nbd_device\" >/dev/null 2>&1; then nbd-client -d \"$nbd_device\" >/dev/null 2>&1 || true; fi",
+		)
+	}
+	script := strings.Join(lines, "\n")
 	return l.runGuestQuiet("sudo", "sh", "-c", script)
 }
 
@@ -390,6 +495,11 @@ func hostMountpointMounted(l *limaVM, mountPoint string) bool {
 }
 
 func (l *limaVM) assertPhysicalDiskBackendLive(disk physicalDiskRuntime) error {
+	if disk.Backend == "vz" {
+		script := fmt.Sprintf("test -b %s && findmnt --noheadings --mountpoint %s >/dev/null", shellQuote(disk.guestDevice), shellQuote(disk.MountPoint))
+		return l.runGuestQuiet("sh", "-c", script)
+	}
+
 	if err := l.waitPIDExists(disk.qemuPidFile()); err != nil {
 		return appendPhysicalDiskLog(err, disk.qemuLogFile(), "qemu-nbd")
 	}

--- a/environment/vm/lima/physical_disk.sh
+++ b/environment/vm/lima/physical_disk.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+set -eu
+
+NAME="$1"
+NBD_DEVICE="$2"
+NBD_PORT="$3"
+MOUNT_POINT="$4"
+FS_TYPE="$5"
+WRITABLE="$6"
+
+EXPORT_FILE="/etc/exports.d/colima-physical-${NAME}.exports"
+EXPORT_ROOT="/mnt/colima/physical"
+EXPORT_ROOT_FILE="/etc/exports.d/colima-physical-root.exports"
+
+install_packages() {
+	if command -v nbd-client >/dev/null 2>&1 && command -v exportfs >/dev/null 2>&1; then
+		return
+	fi
+
+	export DEBIAN_FRONTEND=noninteractive
+	apt-get update
+	apt-get install -y nbd-client nfs-kernel-server
+}
+
+mount_options() {
+	if [ "$WRITABLE" = "true" ]; then
+		echo "rw"
+		return
+	fi
+
+	if [ "$FS_TYPE" = "ext4" ]; then
+		echo "ro,noload"
+		return
+	fi
+
+	echo "ro"
+}
+
+export_options() {
+	if [ "$WRITABLE" = "true" ]; then
+		echo "rw"
+		return
+	fi
+
+	echo "ro"
+}
+
+install_packages
+modprobe nbd max_part=16 || true
+
+if nbd-client -c "$NBD_DEVICE" >/dev/null 2>&1; then
+	nbd-client -d "$NBD_DEVICE" >/dev/null 2>&1 || true
+fi
+
+nbd-client 127.0.0.1 "$NBD_PORT" "$NBD_DEVICE"
+
+DETECTED_TYPE="$(blkid -o value -s TYPE "$NBD_DEVICE" 2>/dev/null || true)"
+if [ -z "$DETECTED_TYPE" ]; then
+	echo "Unable to detect filesystem type for $NBD_DEVICE" >&2
+	exit 1
+fi
+
+if [ "$FS_TYPE" = "" ] || [ "$FS_TYPE" = "auto" ]; then
+	FS_TYPE="$DETECTED_TYPE"
+elif [ "$DETECTED_TYPE" != "$FS_TYPE" ]; then
+	echo "Unexpected filesystem type for $NBD_DEVICE: got $DETECTED_TYPE, expected $FS_TYPE" >&2
+	exit 1
+fi
+
+mkdir -p "$MOUNT_POINT"
+if findmnt --noheadings --mountpoint "$MOUNT_POINT" >/dev/null 2>&1; then
+	umount "$MOUNT_POINT"
+fi
+
+mount -t "$FS_TYPE" -o "$(mount_options)" "$NBD_DEVICE" "$MOUNT_POINT"
+
+mkdir -p "$(dirname "$EXPORT_FILE")"
+mkdir -p "$EXPORT_ROOT"
+cat > "$EXPORT_ROOT_FILE" <<EOF
+$EXPORT_ROOT 127.0.0.1(ro,fsid=0,crossmnt,sync,no_subtree_check,no_root_squash,insecure)
+EOF
+cat > "$EXPORT_FILE" <<EOF
+$MOUNT_POINT 127.0.0.1($(export_options),sync,no_subtree_check,no_root_squash,insecure)
+EOF
+
+systemctl enable --now nfs-server >/dev/null 2>&1 || systemctl enable --now nfs-kernel-server >/dev/null 2>&1
+exportfs -ra
+if [ -w /proc/fs/nfsd/v4_end_grace ]; then
+	echo Y > /proc/fs/nfsd/v4_end_grace 2>/dev/null || true
+fi

--- a/environment/vm/lima/physical_disk.sh
+++ b/environment/vm/lima/physical_disk.sh
@@ -2,24 +2,33 @@
 set -eu
 
 NAME="$1"
-NBD_DEVICE="$2"
-NBD_PORT="$3"
-MOUNT_POINT="$4"
-FS_TYPE="$5"
-WRITABLE="$6"
+BACKEND="$2"
+SOURCE_DEVICE="$3"
+NBD_PORT="$4"
+MOUNT_POINT="$5"
+FS_TYPE="$6"
+WRITABLE="$7"
+HOST_ACCESS="$8"
 
 EXPORT_FILE="/etc/exports.d/colima-physical-${NAME}.exports"
 EXPORT_ROOT="/mnt/colima/physical"
 EXPORT_ROOT_FILE="/etc/exports.d/colima-physical-root.exports"
 
 install_packages() {
-	if command -v nbd-client >/dev/null 2>&1 && command -v exportfs >/dev/null 2>&1; then
+	if { [ "$HOST_ACCESS" != "true" ] || command -v exportfs >/dev/null 2>&1; } && { [ "$BACKEND" != "nbd" ] || command -v nbd-client >/dev/null 2>&1; }; then
 		return
 	fi
 
 	export DEBIAN_FRONTEND=noninteractive
 	apt-get update
-	apt-get install -y nbd-client nfs-kernel-server
+	packages=
+	if [ "$BACKEND" = "nbd" ]; then
+		packages="$packages nbd-client"
+	fi
+	if [ "$HOST_ACCESS" = "true" ]; then
+		packages="$packages nfs-kernel-server"
+	fi
+	apt-get install -y $packages
 }
 
 mount_options() {
@@ -46,24 +55,48 @@ export_options() {
 }
 
 install_packages
-modprobe nbd max_part=16 || true
 
-if nbd-client -c "$NBD_DEVICE" >/dev/null 2>&1; then
-	nbd-client -d "$NBD_DEVICE" >/dev/null 2>&1 || true
-fi
+case "$BACKEND" in
+nbd)
+	modprobe nbd max_part=16 || true
 
-nbd-client 127.0.0.1 "$NBD_PORT" "$NBD_DEVICE"
+	if nbd-client -c "$SOURCE_DEVICE" >/dev/null 2>&1; then
+		nbd-client -d "$SOURCE_DEVICE" >/dev/null 2>&1 || true
+	fi
 
-DETECTED_TYPE="$(blkid -o value -s TYPE "$NBD_DEVICE" 2>/dev/null || true)"
+	nbd-client 127.0.0.1 "$NBD_PORT" "$SOURCE_DEVICE"
+	;;
+vz)
+	i=0
+	while [ "$i" -lt 40 ]; do
+		if [ -e "$SOURCE_DEVICE" ]; then
+			break
+		fi
+		udevadm settle >/dev/null 2>&1 || true
+		i=$((i + 1))
+		sleep 0.25
+	done
+	if [ ! -e "$SOURCE_DEVICE" ]; then
+		echo "Unable to find VZ block device $SOURCE_DEVICE" >&2
+		exit 1
+	fi
+	;;
+*)
+	echo "Unsupported physical disk backend $BACKEND" >&2
+	exit 1
+	;;
+esac
+
+DETECTED_TYPE="$(blkid -o value -s TYPE "$SOURCE_DEVICE" 2>/dev/null || true)"
 if [ -z "$DETECTED_TYPE" ]; then
-	echo "Unable to detect filesystem type for $NBD_DEVICE" >&2
+	echo "Unable to detect filesystem type for $SOURCE_DEVICE" >&2
 	exit 1
 fi
 
 if [ "$FS_TYPE" = "" ] || [ "$FS_TYPE" = "auto" ]; then
 	FS_TYPE="$DETECTED_TYPE"
 elif [ "$DETECTED_TYPE" != "$FS_TYPE" ]; then
-	echo "Unexpected filesystem type for $NBD_DEVICE: got $DETECTED_TYPE, expected $FS_TYPE" >&2
+	echo "Unexpected filesystem type for $SOURCE_DEVICE: got $DETECTED_TYPE, expected $FS_TYPE" >&2
 	exit 1
 fi
 
@@ -72,19 +105,21 @@ if findmnt --noheadings --mountpoint "$MOUNT_POINT" >/dev/null 2>&1; then
 	umount "$MOUNT_POINT"
 fi
 
-mount -t "$FS_TYPE" -o "$(mount_options)" "$NBD_DEVICE" "$MOUNT_POINT"
+mount -t "$FS_TYPE" -o "$(mount_options)" "$SOURCE_DEVICE" "$MOUNT_POINT"
 
-mkdir -p "$(dirname "$EXPORT_FILE")"
-mkdir -p "$EXPORT_ROOT"
-cat > "$EXPORT_ROOT_FILE" <<EOF
+if [ "$HOST_ACCESS" = "true" ]; then
+	mkdir -p "$(dirname "$EXPORT_FILE")"
+	mkdir -p "$EXPORT_ROOT"
+	cat > "$EXPORT_ROOT_FILE" <<EOF
 $EXPORT_ROOT 127.0.0.1(ro,fsid=0,crossmnt,sync,no_subtree_check,no_root_squash,insecure)
 EOF
-cat > "$EXPORT_FILE" <<EOF
+	cat > "$EXPORT_FILE" <<EOF
 $MOUNT_POINT 127.0.0.1($(export_options),sync,no_subtree_check,no_root_squash,insecure)
 EOF
 
-systemctl enable --now nfs-server >/dev/null 2>&1 || systemctl enable --now nfs-kernel-server >/dev/null 2>&1
-exportfs -ra
-if [ -w /proc/fs/nfsd/v4_end_grace ]; then
-	echo Y > /proc/fs/nfsd/v4_end_grace 2>/dev/null || true
+	systemctl enable --now nfs-server >/dev/null 2>&1 || systemctl enable --now nfs-kernel-server >/dev/null 2>&1
+	exportfs -ra
+	if [ -w /proc/fs/nfsd/v4_end_grace ]; then
+		echo Y > /proc/fs/nfsd/v4_end_grace 2>/dev/null || true
+	fi
 fi

--- a/environment/vm/lima/physical_disk_test.go
+++ b/environment/vm/lima/physical_disk_test.go
@@ -45,8 +45,41 @@ func TestNewPhysicalDiskRuntimeDefaults(t *testing.T) {
 	if runtime.nbdGuestPort != physicalDiskGuestNBDPortBase+2 {
 		t.Fatalf("nbdGuestPort = %d", runtime.nbdGuestPort)
 	}
+	if runtime.guestDevice != "" {
+		t.Fatalf("guestDevice = %q, want empty for nbd", runtime.guestDevice)
+	}
 	if filepath.Base(runtime.stateDir) != "src" {
 		t.Fatalf("stateDir = %q", runtime.stateDir)
+	}
+}
+
+func TestNewPhysicalDiskRuntimeVZ(t *testing.T) {
+	config.SetProfile("physical-test")
+	defer config.SetProfile("default")
+
+	runtime, err := newPhysicalDiskRuntime(0, config.PhysicalDisk{
+		Name:    "src",
+		Device:  "/dev/disk0s6",
+		Backend: "vz",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.Backend != "vz" {
+		t.Fatalf("Backend = %q, want vz", runtime.Backend)
+	}
+	if runtime.guestDevice != "/dev/disk/by-id/virtio-disk0s6" {
+		t.Fatalf("guestDevice = %q, want /dev/disk/by-id/virtio-disk0s6", runtime.guestDevice)
+	}
+}
+
+func TestPhysicalDiskGuestBlockDeviceID(t *testing.T) {
+	if got := physicalDiskGuestBlockDeviceID("/dev/disk4s1"); got != "disk4s1" {
+		t.Fatalf("id = %q, want disk4s1", got)
+	}
+	if got := physicalDiskGuestBlockDeviceID("/dev/disk123456789s123456789"); got != "disk123456789s123456" {
+		t.Fatalf("id = %q, want truncated Lima VZ id", got)
 	}
 }
 

--- a/environment/vm/lima/physical_disk_test.go
+++ b/environment/vm/lima/physical_disk_test.go
@@ -1,0 +1,74 @@
+package lima
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/abiosoft/colima/config"
+)
+
+func TestNewPhysicalDiskRuntimeDefaults(t *testing.T) {
+	config.SetProfile("physical-test")
+	defer config.SetProfile("default")
+
+	runtime, err := newPhysicalDiskRuntime(2, config.PhysicalDisk{
+		Name:     "src",
+		Device:   "/dev/disk0s6",
+		FSType:   "ext4",
+		Writable: true,
+		HostAccess: config.PhysicalDiskHostAccess{
+			Enabled: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.RawDevice != "/dev/rdisk0s6" {
+		t.Fatalf("RawDevice = %q, want /dev/rdisk0s6", runtime.RawDevice)
+	}
+	if runtime.Backend != "nbd" {
+		t.Fatalf("Backend = %q, want nbd", runtime.Backend)
+	}
+	if runtime.MountPoint != "/mnt/colima/physical/src" {
+		t.Fatalf("MountPoint = %q", runtime.MountPoint)
+	}
+	if runtime.HostAccess.Driver != "nfs" {
+		t.Fatalf("HostAccess.Driver = %q, want nfs", runtime.HostAccess.Driver)
+	}
+	if runtime.HostAccess.MountPoint != "/Volumes/Colima/src" {
+		t.Fatalf("HostAccess.MountPoint = %q", runtime.HostAccess.MountPoint)
+	}
+	if runtime.nbdDevice != "/dev/nbd2" {
+		t.Fatalf("nbdDevice = %q, want /dev/nbd2", runtime.nbdDevice)
+	}
+	if runtime.nbdGuestPort != physicalDiskGuestNBDPortBase+2 {
+		t.Fatalf("nbdGuestPort = %d", runtime.nbdGuestPort)
+	}
+	if filepath.Base(runtime.stateDir) != "src" {
+		t.Fatalf("stateDir = %q", runtime.stateDir)
+	}
+}
+
+func TestDiskutilMounted(t *testing.T) {
+	if !diskutilMounted("Mounted:                   Yes\n") {
+		t.Fatal("Mounted: Yes was not detected")
+	}
+	if diskutilMounted("Mounted:                   No\n") {
+		t.Fatal("Mounted: No was detected as mounted")
+	}
+}
+
+func TestPhysicalDiskNFSSourcePath(t *testing.T) {
+	source, err := physicalDiskNFSSourcePath("/mnt/colima/physical/src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source != "/src" {
+		t.Fatalf("source = %q, want /src", source)
+	}
+
+	if _, err := physicalDiskNFSSourcePath("/mnt/src"); err == nil {
+		t.Fatal("expected error for mount point outside NFS root")
+	}
+}

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -416,6 +416,12 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 		})
 	}
 
+	for _, disk := range conf.PhysicalDisks {
+		if l.VMType == limaconfig.VZ && physicalDiskBackend(disk) == "vz" {
+			l.BlockDevices = append(l.BlockDevices, disk.Device)
+		}
+	}
+
 	return
 }
 

--- a/environment/vm/lima/yaml_test.go
+++ b/environment/vm/lima/yaml_test.go
@@ -102,6 +102,27 @@ func Test_config_Mounts(t *testing.T) {
 	}
 }
 
+func Test_config_PhysicalDiskVZBlockDevices(t *testing.T) {
+	if !util.MacOS13OrNewer() {
+		t.Skip("VZ blockDevices are macOS-specific")
+	}
+
+	conf, err := newConf(context.Background(), config.Config{
+		VMType: limaconfig.VZ,
+		PhysicalDisks: []config.PhysicalDisk{
+			{Name: "src", Device: "/dev/disk0s6", Backend: "vz"},
+			{Name: "cache", Device: "/dev/disk0s7", Backend: "nbd"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(conf.BlockDevices) != 1 || conf.BlockDevices[0] != "/dev/disk0s6" {
+		t.Fatalf("BlockDevices = %#v, want [/dev/disk0s6]", conf.BlockDevices)
+	}
+}
+
 func Test_ingressDisabled(t *testing.T) {
 	tests := []struct {
 		args []string

--- a/scripts/physical_disk_vz_e2e.sh
+++ b/scripts/physical_disk_vz_e2e.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROFILE="${PROFILE:-physical-vz-e2e-$RANDOM}"
+COLIMA_BINARY="${COLIMA_BINARY:-./_output/binaries/colima-$(uname)-$(uname -m)}"
+LIMA_BIN="${LIMA_BIN:-/tmp/lima-5117/_output/bin/limactl}"
+SECURE_PREFIX="${SECURE_PREFIX:-/opt/colima-vz-e2e}"
+LIMA_SHARE="${LIMA_SHARE:-}"
+LIMA_LIBEXEC="${LIMA_LIBEXEC:-}"
+HOST_MOUNT="${HOST_MOUNT:-/Volumes/Colima/$PROFILE}"
+TMPDIR_ROOT="${TMPDIR_ROOT:-${TMPDIR:-/tmp}}"
+IMAGE_SIZE_MIB="${IMAGE_SIZE_MIB:-256}"
+VISUDO="${VISUDO:-/usr/sbin/visudo}"
+
+tmpdir=""
+image=""
+device=""
+whole_device=""
+profile_dir=""
+sudo_keepalive_pid=""
+
+log() {
+	printf '\n## %s\n' "$*"
+}
+
+die() {
+	printf 'error: %s\n' "$*" >&2
+	exit 1
+}
+
+have_mount() {
+	mount | grep -F " on $1 " >/dev/null 2>&1
+}
+
+cleanup() {
+	set +e
+
+	if [ -n "$sudo_keepalive_pid" ]; then
+		kill "$sudo_keepalive_pid" >/dev/null 2>&1 || true
+	fi
+
+	if [ -x "$COLIMA_BINARY" ]; then
+		PATH="$SECURE_PREFIX/bin:$PATH" "$COLIMA_BINARY" -p "$PROFILE" delete -f >/dev/null 2>&1 || true
+	fi
+
+	if [ -n "$HOST_MOUNT" ] && have_mount "$HOST_MOUNT"; then
+		sudo -n umount "$HOST_MOUNT" >/dev/null 2>&1 || sudo umount "$HOST_MOUNT" >/dev/null 2>&1 || true
+	fi
+	if [ -n "$HOST_MOUNT" ]; then
+		rmdir "$HOST_MOUNT" >/dev/null 2>&1 || sudo -n rmdir "$HOST_MOUNT" >/dev/null 2>&1 || true
+	fi
+
+	if [ -n "$whole_device" ]; then
+		hdiutil detach "$whole_device" >/dev/null 2>&1 || true
+	fi
+
+	if [ -n "$profile_dir" ]; then
+		rm -rf "$profile_dir"
+	fi
+	if [ -n "$tmpdir" ]; then
+		rm -rf "$tmpdir"
+	fi
+
+	sudo -n rm -f /private/etc/sudoers.d/colima-vz-e2e >/dev/null 2>&1 || true
+	sudo -n rm -rf "$SECURE_PREFIX" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+require_cmd() {
+	command -v "$1" >/dev/null 2>&1 || die "$1 not found"
+}
+
+find_lima_assets() {
+	if [ -n "$LIMA_SHARE" ] && [ -n "$LIMA_LIBEXEC" ]; then
+		return
+	fi
+
+	local limactl_path
+	limactl_path="$(command -v limactl || true)"
+	if [ -z "$limactl_path" ]; then
+		die "limactl not found in PATH and LIMA_SHARE/LIMA_LIBEXEC were not set"
+	fi
+
+	local prefix
+	prefix="$(cd "$(dirname "$limactl_path")/.." && pwd)"
+	LIMA_SHARE="${LIMA_SHARE:-$prefix/share/lima}"
+	LIMA_LIBEXEC="${LIMA_LIBEXEC:-$prefix/libexec/lima}"
+
+	[ -d "$LIMA_SHARE" ] || die "Lima share directory not found: $LIMA_SHARE"
+	[ -d "$LIMA_LIBEXEC" ] || die "Lima libexec directory not found: $LIMA_LIBEXEC"
+}
+
+install_secure_lima() {
+	log "installing secure limactl helper"
+
+	[ -x "$LIMA_BIN" ] || die "LIMA_BIN is not executable: $LIMA_BIN"
+	local create_help sudoers_help
+	create_help="$("$LIMA_BIN" create --help 2>&1)"
+	sudoers_help="$("$LIMA_BIN" sudoers --help 2>&1)"
+	[[ "$create_help" == *"--block-device"* ]] || die "$LIMA_BIN lacks create --block-device"
+	[[ "$sudoers_help" == *"--block-device"* ]] || die "$LIMA_BIN lacks sudoers --block-device"
+
+	find_lima_assets
+
+	sudo -v
+	(
+		while true; do
+			sudo -n true >/dev/null 2>&1 || exit 0
+			sleep 60
+		done
+	) &
+	sudo_keepalive_pid="$!"
+
+	sudo install -d -m 0755 "$SECURE_PREFIX/bin" "$SECURE_PREFIX/share" "$SECURE_PREFIX/libexec"
+	sudo install -m 0555 "$LIMA_BIN" "$SECURE_PREFIX/bin/limactl"
+	if [ -x "$(dirname "$LIMA_BIN")/lima" ]; then
+		sudo install -m 0555 "$(dirname "$LIMA_BIN")/lima" "$SECURE_PREFIX/bin/lima"
+	fi
+	sudo rm -f "$SECURE_PREFIX/share/lima" "$SECURE_PREFIX/libexec/lima"
+	sudo ln -s "$LIMA_SHARE" "$SECURE_PREFIX/share/lima"
+	sudo ln -s "$LIMA_LIBEXEC" "$SECURE_PREFIX/libexec/lima"
+
+	local sudoers_tmp sudoers_line sudoers_file
+	sudoers_tmp="$(mktemp "$tmpdir/sudoers.XXXXXX")"
+	sudoers_file="/private/etc/sudoers.d/colima-vz-e2e"
+	LIMA_HOME="$tmpdir/lima-home" "$SECURE_PREFIX/bin/limactl" sudoers --block-device >"$sudoers_tmp.full"
+	sudoers_line="$(grep 'sudo-open-block-device' "$sudoers_tmp.full" || true)"
+	[ -n "$sudoers_line" ] || die "failed to generate sudo-open-block-device sudoers entry"
+	{
+		printf '# Colima physical disk VZ E2E temporary helper\n'
+		printf '%s\n' "$sudoers_line"
+	} >"$sudoers_tmp"
+	sudo "$VISUDO" -cf "$sudoers_tmp" >/dev/null
+	sudo install -o root -g wheel -m 0440 "$sudoers_tmp" "$sudoers_file"
+
+	"$SECURE_PREFIX/bin/limactl" --version
+}
+
+create_ext4_image() {
+	log "creating ext4 disk image"
+
+	tmpdir="$(mktemp -d "$TMPDIR_ROOT/colima-vz-e2e.XXXXXX")"
+	mkdir -p "$tmpdir/lima-home/_config"
+	cat >"$tmpdir/lima-home/_config/networks.yaml" <<EOF
+paths:
+  socketVMNet: ""
+  varRun: /private/var/run/lima
+  sudoers: /private/etc/sudoers.d/colima-vz-e2e
+
+group: everyone
+
+networks:
+  user-v2:
+    mode: user-v2
+    gateway: 192.168.105.1
+    netmask: 255.255.255.0
+EOF
+
+	image="$tmpdir/vz-physical-smoke.img"
+	truncate -s "${IMAGE_SIZE_MIB}m" "$image"
+	perl -e 'use strict; use warnings; my $img=shift; my $size=-s $img; my $sectors=int($size/512); my $start=2048; my $count=$sectors-$start; open my $fh, "+<:raw", $img or die $!; seek $fh, 446, 0; print $fh pack("C C3 C C3 V V", 0, 0,2,0, 0x83, 0xff,0xff,0xff, $start, $count); seek $fh, 510, 0; print $fh "\x55\xaa"; close $fh;' "$image"
+
+	local blocks
+	blocks=$((IMAGE_SIZE_MIB * 1024 - 1024))
+	mke2fs -q -t ext4 -F -L COLIMA_VZ_E2E -E offset=1048576 "$image" "$blocks"
+
+	local attach_out
+	attach_out="$(hdiutil attach -nomount -imagekey diskimage-class=CRawDiskImage "$image")"
+	printf '%s\n' "$attach_out"
+	device="$(printf '%s\n' "$attach_out" | awk '/Linux/ {print $1; exit}')"
+	[ -n "$device" ] || die "failed to find Linux partition in hdiutil output"
+	whole_device="/dev/$(basename "$device" | sed -E 's/s[0-9]+$//')"
+	diskutil info "$device" | grep -q 'Mounted:.*Not applicable\|Mounted:.*No' || die "$device appears mounted on macOS"
+}
+
+write_profile_config() {
+	log "writing Colima profile $PROFILE"
+
+	profile_dir="$HOME/.config/colima/$PROFILE"
+	mkdir -p "$profile_dir"
+	cat >"$profile_dir/colima.yaml" <<EOF
+vmType: vz
+runtime: none
+cpu: 2
+memory: 2
+portForwarder: ssh
+network:
+  address: false
+  mode: shared
+physicalDisks:
+  - name: smoke
+    device: $device
+    fsType: ext4
+    writable: true
+    mountPoint: /mnt/colima/physical/smoke
+    backend: vz
+    hostAccess:
+      enabled: true
+      driver: nfs
+      mountPoint: $HOST_MOUNT
+EOF
+}
+
+run_smoke() {
+	log "starting Colima profile $PROFILE"
+
+	[ -x "$COLIMA_BINARY" ] || die "COLIMA_BINARY is not executable: $COLIMA_BINARY"
+	local colima
+	colima=("$COLIMA_BINARY" -p "$PROFILE")
+
+	PATH="$SECURE_PREFIX/bin:$PATH" "${colima[@]}" start --save-config=false
+
+	log "checking guest mount and read/write"
+	PATH="$SECURE_PREFIX/bin:$PATH" "${colima[@]}" ssh -- sh -lc '
+set -eu
+findmnt --noheadings --mountpoint /mnt/colima/physical/smoke
+blkid /dev/disk/by-id/virtio-'"$(basename "$device")"'
+printf "guest-to-host\n" | sudo tee /mnt/colima/physical/smoke/guest.txt >/dev/null
+test "$(cat /mnt/colima/physical/smoke/guest.txt)" = "guest-to-host"
+'
+
+	log "checking host NFS read/write"
+	test -f "$HOST_MOUNT/guest.txt"
+	test "$(cat "$HOST_MOUNT/guest.txt")" = "guest-to-host"
+	printf 'host-to-guest\n' >"$HOST_MOUNT/host.txt"
+	PATH="$SECURE_PREFIX/bin:$PATH" "${colima[@]}" ssh -- sh -lc 'test "$(cat /mnt/colima/physical/smoke/host.txt)" = "host-to-guest"'
+}
+
+main() {
+	require_cmd hdiutil
+	require_cmd diskutil
+	require_cmd mke2fs
+	require_cmd perl
+	require_cmd truncate
+	require_cmd sudo
+	[ -x "$VISUDO" ] || die "visudo not found: $VISUDO"
+
+	create_ext4_image
+	install_secure_lima
+	write_profile_config
+	run_smoke
+
+	log "Native VZ physical disk E2E passed for profile $PROFILE"
+}
+
+main "$@"

--- a/scripts/physical_disk_vz_e2e.sh
+++ b/scripts/physical_disk_vz_e2e.sh
@@ -219,13 +219,15 @@ findmnt --noheadings --mountpoint /mnt/colima/physical/smoke
 blkid /dev/disk/by-id/virtio-'"$(basename "$device")"'
 printf "guest-to-host\n" | sudo tee /mnt/colima/physical/smoke/guest.txt >/dev/null
 test "$(cat /mnt/colima/physical/smoke/guest.txt)" = "guest-to-host"
+sudo mkdir -p /mnt/colima/physical/smoke/rw-test
+sudo chmod 0777 /mnt/colima/physical/smoke/rw-test
 '
 
 	log "checking host NFS read/write"
 	test -f "$HOST_MOUNT/guest.txt"
 	test "$(cat "$HOST_MOUNT/guest.txt")" = "guest-to-host"
-	printf 'host-to-guest\n' >"$HOST_MOUNT/host.txt"
-	PATH="$SECURE_PREFIX/bin:$PATH" "${colima[@]}" ssh -- sh -lc 'test "$(cat /mnt/colima/physical/smoke/host.txt)" = "host-to-guest"'
+	printf 'host-to-guest\n' >"$HOST_MOUNT/rw-test/host.txt"
+	PATH="$SECURE_PREFIX/bin:$PATH" "${colima[@]}" ssh -- sh -lc 'test "$(cat /mnt/colima/physical/smoke/rw-test/host.txt)" = "host-to-guest"'
 }
 
 main() {

--- a/util/macos.go
+++ b/util/macos.go
@@ -28,6 +28,9 @@ func MacOS13OrNewerOnArm() bool {
 // MacOS13OrNewer returns if the current OS is macOS 13 or newer.
 func MacOS13OrNewer() bool { return minMacOSVersion("13.0.0") }
 
+// MacOS14OrNewer returns if the current OS is macOS 14 or newer.
+func MacOS14OrNewer() bool { return minMacOSVersion("14.0.0") }
+
 // MacOS15OrNewer returns if the current OS is macOS 15 or newer.
 func MacOS15OrNewer() bool { return minMacOSVersion("15.0.0") }
 

--- a/util/qemu.go
+++ b/util/qemu.go
@@ -15,6 +15,16 @@ func AssertQemuImg() error {
 	return nil
 }
 
+// AssertQemuNBD checks if qemu-nbd is available.
+func AssertQemuNBD() error {
+	cmd := "qemu-nbd"
+	if _, err := exec.LookPath(cmd); err != nil {
+		return fmt.Errorf("%s not found, run 'brew install %s' to install", cmd, "qemu")
+	}
+
+	return nil
+}
+
 // AssertKrunkit checks if krunkit is available.
 func AssertKrunkit() error {
 	if _, err := exec.LookPath("krunkit"); err != nil {


### PR DESCRIPTION
## What changed

- Adds `physicalDisks` profile configuration for macOS physical partitions.
- Supports `physicalDisks[].backend` values `auto`, `nbd`, and `vz`; `auto` stays conservative and resolves to `nbd`.
- Implements the NBD backend using host `qemu-nbd`, an SSH tunnel, guest `/dev/nbdN`, and Linux filesystem mounting.
- Implements guarded native VZ block attachment for `vmType: vz` by emitting Lima `blockDevices` and mounting the stable guest path `/dev/disk/by-id/virtio-<device>`.
- Adds optional host access through guest NFSv4 mounted back on macOS, including for the VZ backend.
- Preserves YAML-only config across `colima start` flag merges.
- Documents configuration, warnings, troubleshooting, sudo boundaries, native VZ requirements, E2E testing, and the durability rationale for storing source trees on a physical partition outside the VM disk.
- Adds `scripts/physical_disk_vz_e2e.sh` for repeatable native VZ smoke coverage with a temporary ext4 disk image surrogate.

## Notes

`backend: vz` requires `vmType: vz`, macOS 14 or newer, and a Lima build that exposes secure `--block-device` support in both `limactl create --help` and `limactl sudoers --help`. If those requirements are not met, Colima rejects the config before startup instead of falling back silently.

Host-side sudo is limited to root-only macOS operations. With `backend: nbd`, that means opening the raw partition with `qemu-nbd`, mounting/unmounting the NFS export, and cleaning up root-owned `qemu-nbd`. With `backend: vz`, Lima handles the privileged disk open through its VZ block-device helper during VM startup, and Colima still uses host sudo only for the optional macOS NFS mount/unmount. Guest filesystem setup uses sudo inside the VM.

## Validation

- `go test ./...`
- `go build -o /tmp/colima-vz-physical ./cmd/colima`
- `bash -n scripts/physical_disk_vz_e2e.sh`
- `git diff --check`
- Local NBD smoke with a temporary ext4 disk image attached as `/dev/disk4s1`/`/dev/rdisk4s1`, mounted in the VM as `/dev/nbd0`, exported through NFSv4, and verified read/write in both directions.
- Native VZ smoke using `/tmp/lima-5117/_output/bin/limactl` rebuilt as `v2.2.0` with secure `--block-device` support:
  - VM started with the VZ driver.
  - Guest mounted the ext4 partition through the native block path: `/mnt/colima/physical/smoke /dev/vdb ext4 rw,relatime`.
  - Stable guest ID resolved as expected: `/dev/disk/by-id/virtio-disk4s1 ... TYPE="ext4"`.
  - Guest-to-host and host-to-guest read/write passed through the NFS host-access path.
  - Cleanup audit is clean: no matching hdiutil attachment, no `/Volumes/Colima/physical-vz-e2e*` mount, no `/private/etc/sudoers.d/colima-vz-e2e`, no `/opt/colima-vz-e2e`, no `physical-vz-e2e` Lima instance, and no stale `colima-physical-vz-e2e-*/ssh.sock` mux process.
