### PR TITLE
config: reject mount paths containing spaces

### DIFF
--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -98,6 +98,10 @@ func ValidateConfig(c config.Config) error {
 		}
 	}
 
+	if err := validateMounts(c.Mounts); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -140,5 +144,19 @@ func validateGatewayAddress(gateway net.IP) error {
 		return fmt.Errorf("the last octet of gateway %q is not 2", gateway)
 	}
 
+	return nil
+}
+
+// validateMounts ensures mount paths do not contain spaces, which are not
+// supported by the underlying Lima runtime and otherwise fail silently.
+// See https://github.com/abiosoft/colima/issues/1471.
+func validateMounts(mounts []config.Mount) error {
+	for _, m := range mounts {
+		for _, p := range []string{m.Location, m.MountPoint} {
+			if strings.Contains(p, " ") {
+				return fmt.Errorf("mount path with spaces is not supported by the underlying Lima runtime: %q", p)
+			}
+		}
+	}
 	return nil
 }

--- a/config/configmanager/configmanager_test.go
+++ b/config/configmanager/configmanager_test.go
@@ -1,0 +1,28 @@
+package configmanager
+
+import (
+	"testing"
+
+	"github.com/abiosoft/colima/config"
+)
+
+func TestValidateMounts(t *testing.T) {
+	tests := []struct {
+		name    string
+		mounts  []config.Mount
+		wantErr bool
+	}{
+		{name: "empty", mounts: nil, wantErr: false},
+		{name: "no spaces", mounts: []config.Mount{{Location: "/Users/me/data"}}, wantErr: false},
+		{name: "space in location", mounts: []config.Mount{{Location: "/Volumes/External HD"}}, wantErr: true},
+		{name: "space in mountPoint", mounts: []config.Mount{{Location: "/Volumes/ext", MountPoint: "/mnt/External HD"}}, wantErr: true},
+		{name: "valid then invalid", mounts: []config.Mount{{Location: "/Users/me/ok"}, {Location: "/Volumes/bad dir"}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateMounts(tt.mounts); (err != nil) != tt.wantErr {
+				t.Errorf("validateMounts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -57,6 +57,7 @@
     - [Docker Compose and Buildx showing runc error](#docker-compose-and-buildx-showing-runc-error)
       - [Version v0.5.6 or lower](#version-v056-or-lower)
     - [Issue with Docker bind mount showing empty](#issue-with-docker-bind-mount-showing-empty)
+    - [Mount path with spaces is not supported](#mount-path-with-spaces-is-not-supported)
   - [How can Docker version be updated?](#how-can-docker-version-be-updated)
   - [How can I delete container data](#how-can-i-delete-container-data)
 
@@ -665,6 +666,15 @@ From v0.5.6, start Colima with `--cgroups-v2` flag as a workaround.
 When using docker to bind mount a volume (e.g. using `-v` or `--mount`) from the host where the volume is not contained within `/Users/$USER`, the container will start without raising any errors but the mapped mountpoint on the container will be empty.
 
 This is rectified by mounting the volume on the VM, and only then can docker map the volume or any subdirectory. Edit `$HOME/.colima/default/colima.yaml` and add to the `mounts` section (examples are provided within the yaml file), and then run `colima restart`. Start the container again with the desired bind mount and it should show up correctly.
+
+### Mount path with spaces is not supported
+
+Mount paths containing spaces (e.g. `/Volumes/External HD`) are not supported by the
+underlying [Lima](https://github.com/lima-vm/lima) runtime and will fail to mount.
+
+Colima now rejects such paths at startup with a clear error instead of failing silently.
+As a workaround, mount a parent directory without spaces, or rename/alias the volume to
+avoid spaces. See [#1471](https://github.com/abiosoft/colima/issues/1471).
 
 ## How can Docker version be updated?
 


### PR DESCRIPTION
Mount paths with spaces (e.g. "/Volumes/External HD") fail silently: Colima passes the path to Lima correctly, but the unescaped space breaks the generated /etc/fstab entry and the `nofail` option hides the failure, so the volume is never mounted and no error is shown.

The real fix belongs upstream in Lima. Until then, validate mounts in ValidateConfig and fail fast with a clear error instead of starting with a silently-broken mount, and document the limitation in the FAQ.

Fixes #1471