### PR TITLE
docs: add colima usage skill under skills/

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,13 +221,12 @@ The logo was contributed by [Daniel Hodvogner](https://github.com/dhodvogner). C
 
 Check [here](docs/FAQ.md) for Frequently Asked Questions, or visit the [online FAQ](https://colima.run/docs/faq/) for a searchable version.
 
-Using an AI coding assistant? The [`skills/`](skills/) folder is an Agent Skill that helps Claude Code and other agents give accurate Colima guidance.
-
 ## How to Contribute?
 
 Check [here](docs/CONTRIBUTE.md) for the instructions on contributing to the project.
 
 ## Community
+- [Agent Skill](skills/) — helps Claude Code and other AI assistants give accurate Colima guidance
 - [GitHub Discussions](https://github.com/abiosoft/colima/discussions)
 - [GitHub Issues](https://github.com/abiosoft/colima/issues)
 - [Announcements](https://colima.run/announcements/)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ Check [here](docs/FAQ.md) for Frequently Asked Questions, or visit the [online F
 Check [here](docs/CONTRIBUTE.md) for the instructions on contributing to the project.
 
 ## Community
-- [Agent Skill](skills/) — helps Claude Code and other AI assistants give accurate Colima guidance
 - [GitHub Discussions](https://github.com/abiosoft/colima/discussions)
 - [GitHub Issues](https://github.com/abiosoft/colima/issues)
 - [Announcements](https://colima.run/announcements/)

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ The logo was contributed by [Daniel Hodvogner](https://github.com/dhodvogner). C
 
 Check [here](docs/FAQ.md) for Frequently Asked Questions, or visit the [online FAQ](https://colima.run/docs/faq/) for a searchable version.
 
+Using an AI coding assistant? The [`skills/`](skills/) folder is an Agent Skill that helps Claude Code and other agents give accurate Colima guidance.
+
 ## How to Contribute?
 
 Check [here](docs/CONTRIBUTE.md) for the instructions on contributing to the project.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -60,6 +60,7 @@
     - [Mount path with spaces is not supported](#mount-path-with-spaces-is-not-supported)
   - [How can Docker version be updated?](#how-can-docker-version-be-updated)
   - [How can I delete container data](#how-can-i-delete-container-data)
+  - [How do I use Colima with an AI coding assistant?](#how-do-i-use-colima-with-an-ai-coding-assistant)
 
 ## How does Colima compare to Lima?
 
@@ -687,3 +688,13 @@ From v0.7.6, there is a new `colima update` command to update the container runt
 From v0.9.0, Colima utilises a different disk for the container runtime data. This guards against accidental data loss after deletion and the container data should be reinstated on `colima start`.
 
 To clear all data, `colima delete --data`  should be run instead. The `--data` flag ensures that the container data is also deleted.
+
+## How do I use Colima with an AI coding assistant?
+
+The [`skills/`](../skills/) folder is an Agent Skill — Markdown that AI coding assistants (Claude Code, Cursor, Kimi Code, etc.) load on demand to give accurate, version-aware Colima guidance instead of generic Docker advice. Install it into your assistant's skills directory, e.g.:
+
+```sh
+cp -R skills ~/.claude/skills/colima
+```
+
+See [`skills/README.md`](../skills/README.md) for per-tool instructions and what each file covers.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,50 @@
+# Colima Agent Skill
+
+`SKILL.md` (plus the files in `references/`) is an **Agent Skill** — Markdown with YAML
+frontmatter that an AI coding assistant loads on demand to give accurate, version-aware Colima
+help (install, runtimes, config, troubleshooting, and bootstrap/CI scripting) instead of generic
+Docker advice. It is plain documentation, distilled from this repo's own `docs/`; nothing executes.
+
+## How to use it
+
+The skill is discovered from the assistant's *skills directory*, where each skill lives in its own
+folder. Install it as a skill named `colima`:
+
+### Claude Code
+
+```sh
+# user-level (available in every project)
+cp -R skills ~/.claude/skills/colima
+
+# or project-level
+cp -R skills <your-project>/.claude/skills/colima
+```
+
+Start a new session; the assistant loads the skill automatically when your task involves Colima
+(e.g. *"my colima docker daemon isn't reachable from IntelliJ"*, *"write a CI script that brings
+colima up with kubernetes"*).
+
+### Other agents (Cursor, Kimi Code, …)
+
+Any tool that supports the `SKILL.md` format works the same way — copy this folder into that tool's
+skills directory, e.g.:
+
+```sh
+cp -R skills ~/.kimi-code/skills/colima      # Kimi Code
+```
+
+…or point the tool's skills path at it directly (Kimi Code: `kimi --skills-dir <dir-containing colima/>`).
+
+## What's inside
+
+| File | Contents |
+|---|---|
+| `SKILL.md` | Quick reference + when-to-use (the part the model always sees). |
+| `references/install.md` | Homebrew, MacPorts, Nix, Arch, binary, source. |
+| `references/configuration.md` | Config files, profiles, `COLIMA_HOME`, env into the VM, Lima overrides. |
+| `references/runtimes.md` | Docker, containerd, Kubernetes, Incus, AI models; comparisons. |
+| `references/troubleshooting.md` | Daemon socket errors, `Broken` status, mounts, disk, networking, updates. |
+| `references/automation.md` | Non-interactive patterns for bootstrap / CI / deploy scripts. |
+
+The content mirrors the canonical docs in [`../docs/`](../docs/); version-gated notes (e.g. `since
+vX.Y.Z`) are preserved, so advice stays correct across the versions users run.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: colima
+description: >-
+  Guide to using Colima — container runtimes (Docker, containerd, Kubernetes, Incus) on macOS
+  and Linux via lightweight Lima VMs. Use this skill whenever Colima is (or should be) the
+  container backend: installing Colima; `colima start/stop/status/delete/ssh`; picking or
+  switching a runtime; the `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`
+  error; Docker contexts and socket location; registry mirrors / insecure registries; buildx;
+  bind or volume mounts that show up empty in the container; disk space recovery/resize;
+  reachable VM IP; GPU / AI model workloads; config files, profiles and `COLIMA_HOME`; or a
+  Colima VM that won't start. ALSO use it for **writing scripts that drive Colima** — bootstrap,
+  dev-env, deploy, or CI scripts that bring Colima up non-interactively — because the skill has
+  the correct flags, profile-specific socket paths, idempotent `colima start` guards, and
+  readiness/teardown patterns that hand-written scripts routinely get wrong (e.g. inventing a
+  non-existent flag or hardcoding the wrong docker socket). Prefer this over generic Docker
+  advice whenever Colima is the daemon. This skill is specifically about **Colima** — not Docker
+  Desktop, minikube, Kind, K3d, Rancher Desktop, OrbStack, Podman, or plain `limactl`.
+---
+
+# Colima
+
+Colima runs **container runtimes on macOS (and Linux) with minimal setup**. It's a higher-level
+wrapper over [Lima](https://github.com/lima-vm/lima): it boots a small VM and provisions Docker,
+containerd, Kubernetes and/or Incus inside it, then wires up the host client so `docker` (etc.)
+"just works".
+
+> **Scope:** the canonical source is the repo's own docs (`docs/INSTALL.md`, `docs/FAQ.md`) plus
+> README usage. Behavior is **version-gated** in many places — keep the `vX.Y.Z` notes when
+> advising, since users run a range of versions. Check the user's version with `colima version`.
+
+## Quick start
+
+```sh
+brew install colima      # + docker client if using Docker runtime: brew install docker
+colima start             # boots the VM, Docker runtime by default
+docker run hello-world   # docker client works with no extra setup
+```
+
+Full install options (MacPorts, Nix, Arch, binary, source) → `references/install.md`.
+
+## Core commands
+
+| Command | What it does |
+|---|---|
+| `colima start [profile]` | Create/start the VM. Flags: `--runtime`, `--kubernetes`, `--cpu`, `--memory`, `--disk`, `--edit`, `--env`, `--dns`, `--network-address`, `--vm-type`, `--foreground` |
+| `colima stop [--force]` | Stop the VM. `--force` recovers a `Broken` status |
+| `colima status` | Show running status (incl. Docker socket path) |
+| `colima list` | List profiles and their status/arch/cpus/mem/disk/runtime |
+| `colima restart` | Stop + start (needed after editing mounts/config) |
+| `colima delete [--data]` | Delete the VM. `--data` also deletes container data (since v0.9.0 data lives on a separate disk) |
+| `colima ssh [-- <cmd>]` | Shell into the VM, or run one command |
+| `colima start --edit` | Start while editing the YAML config (since v0.4.0) |
+| `colima template` | Edit the default config template for new instances |
+| `colima update` | Update the container runtime in place (since v0.7.6) |
+| `colima nerdctl ...` | nerdctl wrapper for the containerd runtime |
+| `colima model ...` | Set up / run AI models (GPU, krunkit; since v0.10.0) |
+| `colima version` | Print the version (use it before applying version-gated advice) |
+
+Profiles isolate independent VMs: `colima start work` operates on the `work` profile; default is `default`.
+`colima --help` / `colima start --help` list everything.
+
+## Runtimes — chosen at `start`
+
+Default is Docker. Switch with `--runtime` (changing runtime needs a stop/start).
+
+- **Docker** (default): `colima start` → `docker ...` works directly. Needs the docker client (`brew install docker`).
+- **Containerd**: `colima start --runtime containerd` → use `colima nerdctl ...` (run `colima nerdctl install` to add a `nerdctl` alias to `$PATH`).
+- **Kubernetes**: `colima start --kubernetes` (needs `kubectl`). Shares images with the chosen container runtime.
+- **Incus** (v0.7.0+): `colima start --runtime incus` → `incus ...`.
+- **AI models / GPU** (v0.10.0+, Apple Silicon, macOS 13+): `colima start --runtime docker --vm-type krunkit` then `colima model run gemma3`.
+
+Per-runtime config, socket location, registry mirrors, buildx, nerdctl, AI model registries → `references/runtimes.md`.
+
+> **Registry mirror** (common task): `colima start --registry-mirror <url>` (repeatable) or `--edit` →
+> add under `docker.registry-mirrors`. For the **client** to honor mirrors, the host
+> `~/.docker/daemon.json` may also need the same entries. Details → `references/runtimes.md`.
+
+## Customizing the VM
+
+Defaults: **2 CPUs, 2 GiB memory, 100 GiB disk**. Customize via flags or the config file.
+
+```sh
+colima start --cpu 4 --memory 8 --disk 100      # at create time
+colima stop && colima start --cpu 4 --memory 8  # change an existing VM (disk can only grow)
+colima start --vm-type=vz --vz-rosetta          # Rosetta 2 (v0.5.3+, Apple Silicon, macOS 13+)
+```
+
+Config files, profiles, `COLIMA_HOME`, passing env into the VM, Lima overrides → `references/configuration.md`.
+
+**Writing a bootstrap / CI / deploy script?** See `references/automation.md` for non-interactive patterns:
+idempotent start (`colima status` guard), readiness wait (`docker info` loop), `DOCKER_HOST` wiring so the
+rest of the script targets Colima, `--foreground` for supervisors, teardown, and a GitHub Actions sketch.
+
+## Common gotchas (quick)
+
+- **`Cannot connect to the Docker daemon at unix:///var/run/docker.sock`** — an app isn't using Colima's
+  Docker context. Point it at Colima's socket (`export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"`)
+  or relink the socket. Details + socket location by version → `references/troubleshooting.md`.
+- **`Broken` status** (e.g. after a macOS restart): `colima stop --force`, then `colima start`.
+- **Docker bind mount shows empty** — the host path must be under `/Users/$USER`, or add it to the `mounts`
+  section of the config and `colima restart`. Paths with spaces are unsupported.
+- **Won't start / fatal error** — re-run with `--verbose`; common causes are no virtualization support or an
+  x86_64 Homebrew/Colima on Apple Silicon. See `references/troubleshooting.md`.
+
+Full troubleshooting (no internet/DNS, runc/cgroups error, disk recovery & resize, reachable IP, post-upgrade
+issues, deleting data) → `references/troubleshooting.md`.
+
+## References
+
+- `references/install.md` — all install methods (Homebrew, MacPorts, Nix, Arch, binary, source).
+- `references/configuration.md` — config file & profiles, file locations & env vars, custom VM env, Lima overrides, autostart.
+- `references/runtimes.md` — Docker (socket/contexts/registries/buildx), Containerd, Kubernetes, Incus, AI models; comparisons to Lima/minikube/Kind/K3d.
+- `references/troubleshooting.md` — startup failures, networking, mounts, disk, updates, deleting data.
+- `references/automation.md` — non-interactive patterns for bootstrap / CI / deploy scripts.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -61,7 +61,8 @@ Profiles isolate independent VMs: `colima start work` operates on the `work` pro
 
 ## Runtimes — chosen at `start`
 
-Default is Docker. Switch with `--runtime` (changing runtime needs a stop/start).
+Default is Docker. **Switching the runtime requires re-creating the VM** — a stop/start alone
+does not change it: `colima delete --data && colima start --runtime <new>`.
 
 - **Docker** (default): `colima start` → `docker ...` works directly. Needs the docker client (`brew install docker`).
 - **Containerd**: `colima start --runtime containerd` → use `colima nerdctl ...` (run `colima nerdctl install` to add a `nerdctl` alias to `$PATH`).

--- a/skills/references/automation.md
+++ b/skills/references/automation.md
@@ -1,0 +1,118 @@
+# Automation: bootstrap & deployment scripts
+
+Patterns for driving Colima **non-interactively** — dev-env bootstrap, CI, deploy scripts. The repo
+docs are written for interactive use; this page adapts the same commands into script-safe building
+blocks. Pin behavior to a version (`colima version`) since flags vary.
+
+## 1. Wire the rest of the script to Colima's Docker
+
+A script that runs `docker`/`docker compose` after starting Colima must target Colima's daemon. Two ways:
+
+```sh
+# A) point this shell at Colima's socket (v0.4.0+ path)
+export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
+
+# B) or make Colima the active context (it already sets itself default on start)
+docker context use colima
+```
+
+Don't hardcode the socket blindly — `colima start` already makes itself the default context, so often no
+export is needed. Use the explicit `DOCKER_HOST` when the script runs tools that ignore Docker contexts
+(see `troubleshooting.md`). Confirm the path with `colima status`.
+
+## 2. Idempotent start
+
+Re-running the script shouldn't fail if Colima is already up. `colima status` exits non-zero when the
+profile isn't running:
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="${COLIMA_PROFILE:-default}"
+
+if ! colima status --profile "$PROFILE" >/dev/null 2>&1; then
+  colima start --profile "$PROFILE" \
+    --cpu 4 --memory 8 --disk 100 \
+    --runtime docker
+else
+  echo "colima '$PROFILE' already running"
+fi
+```
+
+Use a dedicated `--profile` to isolate the script's VM from a developer's `default` one (and to allow
+parallel CI jobs).
+
+## 3. Wait for readiness
+
+`colima start` returns when the VM is provisioned, but in CI it's worth confirming the daemon actually
+answers before deploying:
+
+```sh
+for i in $(seq 1 30); do
+  if docker info >/dev/null 2>&1; then break; fi
+  echo "waiting for docker... ($i)"; sleep 2
+done
+docker info >/dev/null   # final check; fails the script if still not ready
+```
+
+## 4. Non-interactive / CI notes
+
+- **No prompts:** lifecycle commands are non-interactive except destructive ones — use `colima delete --force`.
+- **Foreground (v0.5.6+):** `colima start --foreground` keeps Colima in the foreground; useful under a
+  process supervisor (launchd/systemd) or a CI step that owns the lifecycle. Without it, `colima start`
+  backgrounds the VM and returns.
+- **Config over flags:** for reproducible environments, commit a `colima.yaml` and apply it with
+  `colima start --edit` locally, or bake defaults via `colima template`. See `configuration.md`.
+- **Env into the VM:** `colima start --env KEY=value` (repeatable) or the `env:` config block.
+
+## 5. Teardown
+
+```sh
+colima stop --profile "$PROFILE"            # stop, keep the VM
+colima delete --force --profile "$PROFILE"  # remove the VM (data on separate disk since v0.9.0 is kept)
+colima delete --force --data --profile "$PROFILE"  # also wipe container data
+```
+
+## 6. Bootstrap script skeleton
+
+```sh
+#!/usr/bin/env bash
+# Bring up Colima (docker + kubernetes), make docker target it, deploy.
+set -euo pipefail
+PROFILE="${COLIMA_PROFILE:-ci}"
+
+if ! colima status --profile "$PROFILE" >/dev/null 2>&1; then
+  colima start --profile "$PROFILE" --kubernetes --cpu 4 --memory 8 --disk 60
+fi
+
+export DOCKER_HOST="unix://$HOME/.colima/$PROFILE/docker.sock"   # profile-specific socket
+for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 2; done
+
+docker compose up -d            # or: kubectl apply -f k8s/
+# ... deploy / test ...
+
+# teardown (e.g. CI trap):
+# trap 'colima delete --force --profile "$PROFILE"' EXIT
+```
+
+> Note the **profile-specific socket** path `$HOME/.colima/<profile>/docker.sock` — only the `default`
+> profile lives at `.../default/docker.sock`.
+
+## 7. macOS CI (GitHub Actions sketch)
+
+Colima needs a macOS runner (nested virtualization). Rough shape:
+
+```yaml
+jobs:
+  test:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - run: brew install colima docker
+      - run: colima start --cpu 3 --memory 6 --disk 30
+      - run: docker info && docker compose up -d
+      # colima is the default context, so docker just works
+```
+
+Pin Colima/runner versions for reproducibility; resource flags must fit the runner's limits.

--- a/skills/references/configuration.md
+++ b/skills/references/configuration.md
@@ -1,0 +1,113 @@
+# Configuration, profiles & file locations
+
+Source: `docs/FAQ.md`.
+
+## Config file (since v0.4.0)
+
+Colima reads a YAML config instead of repeating CLI flags.
+
+```sh
+colima start --edit        # edit + start (one-off)
+```
+
+- Default config: `$HOME/.colima/default/colima.yaml`
+- Other profiles: `$HOME/.colima/<profile-name>/colima.yaml`
+- Config location root is `$COLIMA_HOME` (defaults to `$HOME/.colima`).
+
+### Default template for new instances
+
+```sh
+colima template                    # edit the default template
+```
+
+Template file: `$HOME/.colima/_templates/default.yaml`.
+
+### Choosing the editor
+
+Set `$EDITOR`, or pass `--editor`:
+
+```sh
+colima start --edit --editor code   # one-off
+colima template --editor code       # default config
+```
+
+## File-location environment variables (set on the host)
+
+| Variable | Description |
+|---|---|
+| `COLIMA_HOME` | Colima config directory (default `$HOME/.colima`) |
+| `COLIMA_CACHE_HOME` | Cache directory (host-specific default, see Go `os.UserCacheDir()`) |
+| `COLIMA_PROFILE` | Active profile name (default `default`) |
+| `DOCKER_CONFIG` | Docker client config dir (default `~/.docker`) |
+
+## Passing custom env vars into the VM
+
+Config file:
+
+```yaml
+env:
+  MY_VAR: value
+```
+
+Or CLI:
+
+```sh
+colima start --env MY_VAR=value
+# verify inside the VM:
+colima ssh -- sh -c 'env | grep MY_VAR'
+```
+
+## Autostart
+
+- Foreground mode (since v0.5.6): `colima start --foreground`.
+- Installed via brew: `brew services start colima`.
+
+## Lima overrides (advanced users only)
+
+Lima supports `override.yaml` (applied **before** the instance config) and `default.yaml` (applied
+**after**, as fallback defaults).
+
+Override file: `$HOME/.colima/_lima/_config/override.yaml` (or `$LIMA_HOME/_config/override.yaml` if
+`LIMA_HOME` is set).
+
+> Overriding the **image** is not supported — Colima's image bundles dependencies a custom image would lack.
+
+### Example: provision scripts (run during VM boot)
+
+```yaml
+# $HOME/.colima/_lima/_config/override.yaml
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      apt-get update && apt-get install -y curl
+```
+
+Or directly in `colima.yaml` via `colima start --edit`:
+
+```diff
+- provision: []
++ provision:
++   - mode: system
++     script: |
++       #!/bin/bash
++       set -eux -o pipefail
++       apt-get update && apt-get install -y curl
+```
+
+## Reachable VM IP (macOS only)
+
+Disabled by default (needs root, slower startup). Enable per-start or in config:
+
+```sh
+colima start --network-address
+```
+
+```diff
+network:
+-  address: false
++  address: true
+```
+
+(For Incus reachability from the host this is required — see `runtimes.md`.)

--- a/skills/references/install.md
+++ b/skills/references/install.md
@@ -1,0 +1,63 @@
+# Installing Colima
+
+Source: `docs/INSTALL.md`. Requires macOS 13+ (or Linux). Docker runtime also needs a docker client
+(`brew install docker`).
+
+## Homebrew
+
+```sh
+brew install colima          # stable
+brew install --HEAD colima   # development version
+```
+
+## MacPorts
+
+```sh
+sudo port install colima
+```
+
+## Nix
+
+```sh
+nix-env -i colima            # install (stable only)
+nix-shell -p colima          # or use only within a nix-shell
+```
+
+## Arch
+
+```sh
+sudo pacman -S qemu-full go docker   # dependencies
+yay -S lima-bin colima-bin           # Lima + Colima from AUR
+```
+
+## Binary
+
+Binaries ship with every [release](https://github.com/abiosoft/colima/releases).
+
+```sh
+# download binary
+curl -LO https://github.com/abiosoft/colima/releases/latest/download/colima-$(uname)-$(uname -m)
+
+# install in $PATH
+sudo install colima-$(uname)-$(uname -m) /usr/local/bin/colima
+```
+
+## Building from source
+
+Requires [Go](https://golang.org).
+
+```sh
+git clone https://github.com/abiosoft/colima
+cd colima
+make
+sudo make install
+```
+
+## Notes
+
+- Colima requires **macOS 13 or newer**. On older macOS you may be able to build Colima and its
+  dependencies ([Lima](https://github.com/lima-vm/lima), [Qemu](https://www.qemu.org/)) from source.
+- Both Intel and Apple Silicon Macs are supported.
+- Updating: `brew upgrade colima`, then `colima delete && colima start` to recreate the VM on the new
+  image. The container runtime alone can be updated with `colima update` (v0.7.6+). See
+  `troubleshooting.md` → updates.

--- a/skills/references/runtimes.md
+++ b/skills/references/runtimes.md
@@ -1,7 +1,12 @@
 # Runtimes: Docker, Containerd, Kubernetes, Incus, AI
 
 Sources: `README.md` (usage) + `docs/FAQ.md` (config/details). Runtime is chosen at `colima start`
-(default Docker); changing it needs a stop/start.
+(default Docker). **Switching to a different runtime requires re-creating the VM** — a stop/start
+alone does not change it:
+
+```sh
+colima delete --data && colima start --runtime <new runtime>
+```
 
 ## Docker
 

--- a/skills/references/runtimes.md
+++ b/skills/references/runtimes.md
@@ -1,0 +1,148 @@
+# Runtimes: Docker, Containerd, Kubernetes, Incus, AI
+
+Sources: `README.md` (usage) + `docs/FAQ.md` (config/details). Runtime is chosen at `colima start`
+(default Docker); changing it needs a stop/start.
+
+## Docker
+
+```sh
+colima start            # docker runtime
+docker run hello-world
+docker ps
+```
+
+Colima leverages **Docker contexts** and can run alongside Docker Desktop (since v0.3.0); it makes
+itself the default context on startup.
+
+### Socket location (version-gated)
+
+| Version | Docker socket |
+|---|---|
+| v0.3.4 or older | `$HOME/.colima/docker.sock` |
+| v0.4.0 or newer | `$HOME/.colima/default/docker.sock` |
+
+Also shown by `colima status`.
+
+### Docker contexts
+
+```sh
+docker context list           # list contexts
+docker context use <name>     # switch active context
+```
+
+### Customizing the Docker daemon (insecure registries, mirrors)
+
+- v0.3.4 or lower: edit `$HOME/.colima/docker/daemon.json` (generated on first start), then restart.
+- v0.4.0+: `colima start --edit` and add under the `docker:` section:
+
+  ```diff
+  - docker: {}
+  + docker:
+  +   insecure-registries:
+  +     - myregistry.com:5000
+  +   registry-mirrors:
+  +     - https://my.dockerhub.mirror.something
+  ```
+
+Registry mirrors can also be set at start (repeatable flag), no editing needed:
+
+```sh
+colima start --registry-mirror https://my.dockerhub.mirror.something
+```
+
+> The host `~/.docker/daemon.json` may also need matching changes for the **client** to honor some
+> values (e.g. registry mirrors). Use `colima template` to bake changes into all new instances.
+
+### Buildx plugin missing
+
+```sh
+brew install docker-buildx
+mkdir -p ~/.docker/cli-plugins
+ln -sfn $(which docker-buildx) ~/.docker/cli-plugins/docker-buildx
+docker buildx version
+```
+
+## Containerd
+
+```sh
+colima start --runtime containerd
+colima nerdctl install      # add a `nerdctl` alias to $PATH (recommended)
+nerdctl run hello-world
+nerdctl ps
+```
+
+### Config files (first start with containerd)
+
+| File | Location |
+|---|---|
+| Containerd config | `~/.config/containerd/config.toml` |
+| BuildKit config | `~/.config/buildkit/buildkitd.toml` |
+
+Shared across profiles; edit then `colima stop && colima start --runtime containerd`.
+`$XDG_CONFIG_HOME` is respected if set.
+
+**Per-profile override:** place the file at `$HOME/.colima/<profile>/containerd/config.toml` (or
+`buildkitd.toml`). Resolution order: per-profile override → central (`~/.config/...`) → embedded default.
+
+## Kubernetes
+
+```sh
+colima start --kubernetes    # needs kubectl (brew install kubectl)
+kubectl run caddy --image=caddy
+kubectl get pods
+```
+
+Image registry sharing: Docker runtime — images built/pulled with Docker are available to Kubernetes;
+Containerd runtime — images in the `k8s.io` namespace are available.
+
+## Incus (v0.7.0+)
+
+```sh
+colima start --runtime incus    # needs incus (brew install incus)
+incus launch images:alpine/edge
+incus list
+```
+
+Running **VMs** on Incus needs an M3 or newer Apple Silicon device. Incus instances aren't reachable
+from the host by default (v0.10.0+) — enable network address:
+
+```sh
+colima stop
+colima start --network-address
+```
+
+## AI models / GPU (v0.10.0+, Apple Silicon, macOS 13+)
+
+Uses the `krunkit` VM type (install [krunkit](https://github.com/containers/krunkit#installation) first).
+
+```sh
+colima start --runtime docker --vm-type krunkit
+colima model setup
+colima model run gemma3
+```
+
+Two runner backends: **Docker Model Runner** (default — Docker AI Registry + HuggingFace) and
+**Ramalama** (HuggingFace + Ollama). Registry examples:
+
+```sh
+colima model run gemma3                      # Docker AI Registry (default, no prefix)
+colima model run hf://tinyllama              # HuggingFace
+colima model run ollama://tinyllama --runner ramalama   # Ollama (ramalama runner)
+```
+
+`colima model --help` for more.
+
+## How Colima compares
+
+- **vs Lima:** Colima is a higher-level use of Lima — it uses Lima to provide Docker/Containerd/Kubernetes.
+- **vs minikube/Kind/K3d (Kubernetes):** those suit multiple clusters or when you don't need Docker and
+  Kubernetes to share images/runtime. Colima with Docker runtime is fully compatible with them.
+- **vs minikube (Docker):** minikube can expose its Docker via `minikube docker-env`, but Kubernetes is
+  not optional there, and its free macOS drivers fall short on performance/port-forwarding/volumes for
+  Docker-only use.
+
+## Distro / underlying VM
+
+- v0.5.6 and lower: lightweight Alpine image; optional Ubuntu **layer** via `colima start --layer=true`
+  (with the layer, `ssh`/`ssh-config` route to the layer; use `--layer=false` to reach the underlying VM).
+- v0.6.0 and newer: Ubuntu is the underlying image; other distros aren't supported.

--- a/skills/references/troubleshooting.md
+++ b/skills/references/troubleshooting.md
@@ -1,0 +1,129 @@
+# Troubleshooting
+
+Source: `docs/FAQ.md`. Many fixes are version-gated — check `colima version` first.
+
+## `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`
+
+Colima uses Docker contexts and sets itself as the default context on start, but some apps ignore
+contexts. Fix with any of (confirm the socket path first — see socket location in `runtimes.md`):
+
+1. Set an app-specific Docker socket path if supported (e.g. JetBrains IDEs).
+2. Point `DOCKER_HOST` at Colima's socket:
+   ```sh
+   export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
+   ```
+3. Link Colima's socket to the default path (**may break other Docker servers**):
+   ```sh
+   sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+   ```
+
+## Colima not starting
+
+### Broken status
+
+`colima list` shows `Broken` (often after a macOS restart). Force-stop, then start:
+
+```sh
+colima stop --force
+colima start
+```
+
+### `FATA[0000] error starting vm: error at 'starting': exit status 1`
+
+Enable debug logging to investigate:
+
+```sh
+colima start --verbose
+```
+
+If the log shows `exiting, status={Running:false Degraded:false Exiting:true ...}`, it's almost always
+either (1) a device without virtualization support, or (2) an x86_64 Homebrew/Colima on an Apple Silicon (M1) device.
+
+### Issues after an upgrade
+
+Test with a separate profile; if it starts cleanly, reset the default profile:
+
+```sh
+colima start debug      # separate profile
+# if that works:
+colima delete
+colima start
+```
+
+## Colima cannot access the internet
+
+Usually DNS. Try custom DNS servers and verify from inside the VM:
+
+```sh
+colima start --dns 8.8.8.8 --dns 1.1.1.1
+colima ssh -- ping -c4 google.com
+```
+
+## Docker Compose / Buildx `runc ... cgroup ... invalid argument` (v0.5.6 or lower)
+
+Workaround from v0.5.6: start with `--cgroups-v2`. **Fixed in v0.6.0.**
+
+```sh
+colima start --cgroups-v2
+```
+
+## Docker bind mount shows empty
+
+Bind-mounting a host path **not** under `/Users/$USER` starts the container without error but the
+mountpoint is empty. Mount it on the VM first: edit `$HOME/.colima/default/colima.yaml`, add the path
+to the `mounts` section (examples are in the file), then `colima restart` and re-run the container.
+
+## Mount path with spaces is not supported
+
+Paths with spaces (e.g. `/Volumes/External HD`) aren't supported by the underlying Lima runtime; Colima
+rejects them at startup with a clear error. Workaround: mount a parent dir without spaces, or rename/alias
+the volume. See [#1471](https://github.com/abiosoft/colima/issues/1471).
+
+## Disk space
+
+### Recover space
+
+Free space in the VM with `docker system prune` or by removing containers. On v0.4.x or lower this
+doesn't reflect on the host.
+
+- v0.5.0+: unused VM disk space is released on startup — a `colima restart` suffices.
+- v0.5.0+: manual trim:
+  ```sh
+  colima ssh -- sudo fstrim -a      # add -v for verbose
+  ```
+
+### Increase disk size (v0.5.3+)
+
+Disk grows on startup from `colima.yaml`:
+
+```diff
+- disk: 150
++ disk: 250
+```
+
+## Updating
+
+- **Colima itself:** `brew upgrade colima`, then recreate the VM to use the new image:
+  ```sh
+  colima delete
+  colima start
+  ```
+  Test an upgrade safely on a separate profile: `colima start debug`.
+- **Container runtime only (v0.7.6+):** `colima update` — updates Docker/containerd without updating
+  Colima or waiting for a release.
+
+## Accessing the VM directly
+
+```sh
+colima ssh                 # interactive shell
+colima ssh -- uname -a     # one-off command
+```
+
+## Deleting container data
+
+Since v0.9.0 container data lives on a separate disk, so `colima delete` preserves it (reinstated on
+`colima start`). To wipe everything including data:
+
+```sh
+colima delete --data
+```


### PR DESCRIPTION
Hi! First off — Colima is fantastic and has saved me a lot of headaches running containers on macOS. While using it I put together a small **Agent Skill** that helps AI coding assistants (Claude Code, Cursor, etc.) assist users with Colima accurately, and I'd love to contribute it back.

## What this adds

A documentation-only top-level `skills/` folder: a `SKILL.md` plus topic references (`install`, `configuration`, `runtimes`, `troubleshooting`, `automation`). An "Agent Skill" is just Markdown with YAML frontmatter that AI assistants load on demand. This one packages the guidance **already in this repo's `docs/`** (`INSTALL.md`, `FAQ.md`) and README usage into that structured format, so assistants give accurate, version-aware Colima advice — correct flags, socket paths, `colima stop --force` for a `Broken` status, registry mirrors, idempotent start in scripts — instead of generic Docker guidance.

- Docs-only; no code or behavior change.
- Version-gated notes from the FAQ are preserved.

## LLM usage disclosure

Per `docs/CONTRIBUTE.md`: the Markdown was generated with an LLM (Claude) by summarizing this repository's own `docs/INSTALL.md`, `docs/FAQ.md`, and README usage, then reviewed by me for accuracy. It is **documentation only — no code** — and stays faithful to the existing docs. Each file is small and self-contained for easy review.

## Notes

- DCO signed off.
- Entirely at your discretion — happy to revise, relocate, or close if a skill folder isn't something you'd want to maintain here. Thanks for Colima!