### PR TITLE
core: fall back to the XDG default config dir when the variable is unset

### DIFF
--- a/config/files.go
+++ b/config/files.go
@@ -67,20 +67,34 @@ var (
 
 			// extra xdg config directory
 			xdgDir, xdg := os.LookupEnv("XDG_CONFIG_HOME")
+			if xdgDir == "" {
+				// the XDG spec treats an unset or empty variable as ~/.config.
+				// resolving the default keeps processes started without a shell
+				// environment (e.g. launchd via `brew services`) on the same
+				// config directory as interactive runs.
+				xdg = false
+				xdgDir = filepath.Join(homeDir, ".config")
+			}
+			xdgColimaDir := filepath.Join(xdgDir, "colima")
 
 			if err == nil {
 				// ~/.colima is found but xdg dir is set
 				if xdg {
 					logrus.Warnln("found ~/.colima, ignoring $XDG_CONFIG_HOME...")
 					logrus.Warnln("delete ~/.colima to use $XDG_CONFIG_HOME as config directory")
-					logrus.Warnf("or run `mv ~/.colima \"%s\"`", filepath.Join(xdgDir, "colima"))
+					logrus.Warnf("or run `mv ~/.colima \"%s\"`", xdgColimaDir)
 				}
 				return dir, nil
-			} else {
-				// ~/.colima is missing and xdg dir is set
-				if xdg {
-					return filepath.Join(xdgDir, "colima"), nil
-				}
+			}
+
+			// ~/.colima is missing and xdg dir is set
+			if xdg {
+				return xdgColimaDir, nil
+			}
+
+			// ~/.colima is missing and the xdg default dir is already in use
+			if _, err := os.Stat(xdgColimaDir); err == nil {
+				return xdgColimaDir, nil
 			}
 
 			// macOS users are accustomed to ~/.colima

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -119,7 +119,12 @@ Yes, from v0.4.0, Colima support YAML configuration file.
 
 ### Specifying the config location
 
-Set the `$COLIMA_HOME` environment variable, otherwise it defaults to `$HOME/.colima`.
+Set the `$COLIMA_HOME` environment variable. When it is not set, the first match wins:
+
+1. `$HOME/.colima`, if it exists
+2. `$XDG_CONFIG_HOME/colima`, if the variable is set
+3. `~/.config/colima`, if it exists (the XDG default when the variable is unset)
+4. otherwise `$HOME/.colima` on macOS, and the user config directory on other platforms
 
 ### Editing the config
 


### PR DESCRIPTION
Fixes #1431

## Problem

Colima honors `XDG_CONFIG_HOME` when run interactively, but a start via `brew services` runs under launchd with no shell environment. With the variable unset and `~/.colima` absent, the macOS fallback created `~/.colima` - and from then on every run preferred the legacy directory over the XDG one, with the `found ~/.colima, ignoring $XDG_CONFIG_HOME` warning.

## Change

- Treat an unset or empty `XDG_CONFIG_HOME` as `~/.config`, per the XDG Base Directory spec.
- Adopt an existing `~/.config/colima` before falling back to creating the legacy macOS directory.
- Precedence is otherwise unchanged: `COLIMA_HOME` first, an existing `~/.colima` still wins, an explicitly set `XDG_CONFIG_HOME` behaves as before, and fresh installs on macOS still default to `~/.colima`.
- FAQ now documents the resolution order.

## Verification

Binaries built from `main` and from this branch, each scenario in an isolated `$HOME` with a scrubbed environment (`env -i`, mirroring launchd):

| Scenario | main | this branch |
|---|---|---|
| Fresh, no env | creates `~/.colima` | unchanged |
| Fresh, `XDG_CONFIG_HOME` set | uses `$XDG_CONFIG_HOME/colima` | unchanged |
| `~/.config/colima` exists, env unset (the `brew services` case) | creates a second dir at `~/.colima` | uses `~/.config/colima`; `~/.colima` is not created |
| `~/.colima` exists, `XDG_CONFIG_HOME` set | legacy wins, with warning | unchanged |

`go test ./...` passes, `gofmt` clean.

Note: setups that already have both directories keep current behavior (the legacy dir wins); this change prevents the split from arising in the first place.