### PR TITLE
core: update mount type for krunkit VM to virtiofs when 9p is specified

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -363,6 +363,13 @@ func setFlagDefaults(cmd *cobra.Command) {
 				log.Warnf("9p is only available for 'qemu' vmType, using %s", defaultMountTypeVZ)
 			}
 		}
+		// convert mount type for krunkit
+		if startCmdArgs.VMType == "krunkit" && startCmdArgs.MountType == "9p" {
+			startCmdArgs.MountType = "virtiofs"
+			if cmd.Flag("mount-type").Changed {
+				log.Warnf("9p is not supported for 'krunkit' vmType, using virtiofs")
+			}
+		}
 	}
 
 	// always enable nested virtualization for incus, if supported and not explicitly disabled.


### PR DESCRIPTION
### Description

Currently, starting Colima with `--vm-type krunkit` fails immediately if `--mount-type` is not explicitly set, because the configuration defaults to `9p`. The krunkit driver only supports `virtiofs` or `reverse-sshfs`, resulting in the following fatal error:

`rpc error: code = Unknown desc = field mountType must be virtiofs or reverse-sshfs for krunkit driver, got 9p`

### Changes

This PR adds the missing fallback logic in `cmd/start.go` (inside `setFlagDefaults`). It automatically updates the `mountType` to `virtiofs` when `krunkit` is used and `9p` is currently specified. 

This mirrors the existing behavior that is already implemented for the `vz` vmType, allowing users to start a krunkit VM smoothly without manually overriding the mount type.