### PR TITLE
core: fix krunkit virtiofs configuration

### DIFF
--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -339,16 +339,7 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 		}
 	}
 
-	switch strings.ToLower(conf.MountType) {
-	case "ssh", "sshfs", "reversessh", "reverse-ssh", "reversesshfs", limaconfig.REVSSHFS:
-		l.MountType = limaconfig.REVSSHFS
-	default:
-		if l.VMType == limaconfig.VZ {
-			l.MountType = limaconfig.VIRTIOFS
-		} else { // qemu
-			l.MountType = limaconfig.NINEP
-		}
-	}
+	l.MountType = resolveMountType(l.VMType, conf.MountType)
 
 	/*
 		provision scripts for disk actions
@@ -420,6 +411,18 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 }
 
 type Arch = environment.Arch
+
+func resolveMountType(vmType limaconfig.VMType, mountType string) limaconfig.MountType {
+	switch strings.ToLower(mountType) {
+	case "ssh", "sshfs", "reversessh", "reverse-ssh", "reversesshfs", limaconfig.REVSSHFS:
+		return limaconfig.REVSSHFS
+	default:
+		if vmType == limaconfig.VZ || vmType == limaconfig.Krunkit {
+			return limaconfig.VIRTIOFS
+		}
+		return limaconfig.NINEP
+	}
+}
 
 func selectPath(m config.Mount) (string, error) {
 	if m.MountPoint != "" {

--- a/environment/vm/lima/yaml_test.go
+++ b/environment/vm/lima/yaml_test.go
@@ -102,6 +102,29 @@ func Test_config_Mounts(t *testing.T) {
 	}
 }
 
+func Test_resolveMountType(t *testing.T) {
+	tests := []struct {
+		name      string
+		vmType    limaconfig.VMType
+		mountType string
+		want      limaconfig.MountType
+	}{
+		{name: "qemu defaults to 9p", vmType: limaconfig.QEMU, want: limaconfig.NINEP},
+		{name: "vz defaults to virtiofs", vmType: limaconfig.VZ, want: limaconfig.VIRTIOFS},
+		{name: "krunkit defaults to virtiofs", vmType: limaconfig.Krunkit, want: limaconfig.VIRTIOFS},
+		{name: "krunkit supports explicit virtiofs", vmType: limaconfig.Krunkit, mountType: limaconfig.VIRTIOFS, want: limaconfig.VIRTIOFS},
+		{name: "krunkit supports sshfs", vmType: limaconfig.Krunkit, mountType: "sshfs", want: limaconfig.REVSSHFS},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveMountType(tt.vmType, tt.mountType); got != tt.want {
+				t.Errorf("resolveMountType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_ingressDisabled(t *testing.T) {
 	tests := []struct {
 		args []string

--- a/environment/vm/lima/yaml_test.go
+++ b/environment/vm/lima/yaml_test.go
@@ -109,11 +109,11 @@ func Test_resolveMountType(t *testing.T) {
 		mountType string
 		want      limaconfig.MountType
 	}{
-		{name: "qemu defaults to 9p", vmType: limaconfig.QEMU, want: limaconfig.NINEP},
-		{name: "vz defaults to virtiofs", vmType: limaconfig.VZ, want: limaconfig.VIRTIOFS},
-		{name: "krunkit defaults to virtiofs", vmType: limaconfig.Krunkit, want: limaconfig.VIRTIOFS},
-		{name: "krunkit supports explicit virtiofs", vmType: limaconfig.Krunkit, mountType: limaconfig.VIRTIOFS, want: limaconfig.VIRTIOFS},
-		{name: "krunkit supports sshfs", vmType: limaconfig.Krunkit, mountType: "sshfs", want: limaconfig.REVSSHFS},
+		{name: "qemu keeps explicit 9p", vmType: limaconfig.QEMU, mountType: limaconfig.NINEP, want: limaconfig.NINEP},
+		{name: "qemu maps sshfs to reverse-sshfs", vmType: limaconfig.QEMU, mountType: "sshfs", want: limaconfig.REVSSHFS},
+		{name: "vz converts 9p to virtiofs", vmType: limaconfig.VZ, mountType: limaconfig.NINEP, want: limaconfig.VIRTIOFS},
+		{name: "krunkit converts 9p to virtiofs", vmType: limaconfig.Krunkit, mountType: limaconfig.NINEP, want: limaconfig.VIRTIOFS},
+		{name: "krunkit maps sshfs to reverse-sshfs", vmType: limaconfig.Krunkit, mountType: "sshfs", want: limaconfig.REVSSHFS},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What changed

- Treat krunkit like VZ when generating Lima's default mount type.
- Keep explicit SSHFS aliases mapped to `reverse-sshfs`.
- Add platform-independent regression coverage for QEMU, VZ, and krunkit mount resolution.

## Why

The CLI now converts krunkit's unsupported `9p` mount type to `virtiofs`, but the Lima configuration generator still treated every non-VZ backend as QEMU and emitted `9p`. As a result, starting krunkit failed Lima validation even when `virtiofs` was requested.

This change keeps the generated Lima configuration consistent with the CLI behavior added in #1609.

## Impact

`colima start --vm-type krunkit --mount-type virtiofs` now generates a valid `virtiofs` Lima configuration. Existing QEMU, VZ, and SSHFS behavior is preserved.

## Validation

- `go test ./...`
- `gofmt`
- `git diff --check`

## LLM usage disclosure

OpenAI Codex using GPT-5.6-sol was used to investigate the root cause, implement the focused mount-type resolver change, and generate the regression tests. The resulting diff was inspected, formatted, and validated with the full Go test suite.
