### PR TITLE
config: reject uppercase http(s) diskImage URLs

### DIFF
--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -82,10 +82,8 @@ func ValidateConfig(c config.Config) error {
 		}
 	}
 
-	if c.DiskImage != "" {
-		if strings.HasPrefix(c.DiskImage, "http://") || strings.HasPrefix(c.DiskImage, "https://") {
-			return fmt.Errorf("cannot use diskImage: remote URLs not supported, only local files can be specified")
-		}
+	if err := validateDiskImage(c.DiskImage); err != nil {
+		return err
 	}
 
 	if _, ok := validPortForwarders[c.PortForwarder]; !ok {
@@ -157,6 +155,24 @@ func validateMounts(mounts []config.Mount) error {
 				return fmt.Errorf("mount path with spaces is not supported by the underlying Lima runtime: %q", p)
 			}
 		}
+	}
+	return nil
+}
+
+// validateDiskImage ensures the diskImage is a local file path. Remote URLs
+// with an http or https scheme are not supported by the Lima image-loading
+// path and fail later with a confusing os.Stat "file not found" error, so
+// reject them here with a clear message.
+// The scheme match is case-insensitive per RFC 3986 §3.1, so HTTP:// and
+// HTTPS:// (and any mixed-case variant) are treated the same as http:// and
+// https://. The empty string is allowed and is the default.
+func validateDiskImage(diskImage string) error {
+	if diskImage == "" {
+		return nil
+	}
+	lower := strings.ToLower(diskImage)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return fmt.Errorf("cannot use diskImage: remote URLs not supported, only local files can be specified")
 	}
 	return nil
 }

--- a/config/configmanager/configmanager_test.go
+++ b/config/configmanager/configmanager_test.go
@@ -26,3 +26,32 @@ func TestValidateMounts(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDiskImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		diskImage string
+		wantErr   bool
+	}{
+		{name: "empty", diskImage: "", wantErr: false},
+		{name: "plain local path", diskImage: "/Users/me/colima.img", wantErr: false},
+		{name: "relative local path", diskImage: "images/colima.img", wantErr: false},
+		{name: "local path with spaces", diskImage: "/Volumes/My Disk/colima.img", wantErr: false},
+		{name: "http lowercase", diskImage: "http://example.com/colima.img", wantErr: true},
+		{name: "https lowercase", diskImage: "https://example.com/colima.img", wantErr: true},
+		{name: "HTTP uppercase", diskImage: "HTTP://example.com/colima.img", wantErr: true},
+		{name: "HTTPS uppercase", diskImage: "HTTPS://example.com/colima.img", wantErr: true},
+		{name: "Https mixed case", diskImage: "Https://example.com/colima.img", wantErr: true},
+		{name: "hTTp mixed case", diskImage: "hTTp://example.com/colima.img", wantErr: true},
+		{name: "HtTpS mixed case", diskImage: "HtTpS://example.com/colima.img", wantErr: true},
+		{name: "httplocal is a distinct scheme, not http", diskImage: "httplocal://x", wantErr: false},
+		{name: "unrelated scheme not in scope", diskImage: "ftp://example.com/x", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateDiskImage(tt.diskImage); (err != nil) != tt.wantErr {
+				t.Errorf("validateDiskImage(%q) error = %v, wantErr %v", tt.diskImage, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -58,6 +58,7 @@
       - [Version v0.5.6 or lower](#version-v056-or-lower)
     - [Issue with Docker bind mount showing empty](#issue-with-docker-bind-mount-showing-empty)
     - [Mount path with spaces is not supported](#mount-path-with-spaces-is-not-supported)
+    - [Disk image must be a local file](#disk-image-must-be-a-local-file)
   - [How can Docker version be updated?](#how-can-docker-version-be-updated)
   - [How can I delete container data](#how-can-i-delete-container-data)
   - [How do I use Colima with an AI coding assistant?](#how-do-i-use-colima-with-an-ai-coding-assistant)
@@ -681,6 +682,18 @@ underlying [Lima](https://github.com/lima-vm/lima) runtime and will fail to moun
 Colima now rejects such paths at startup with a clear error instead of failing silently.
 As a workaround, mount a parent directory without spaces, or rename/alias the volume to
 avoid spaces. See [#1471](https://github.com/abiosoft/colima/issues/1471).
+
+### Disk image must be a local file
+
+The `--disk-image` flag (and the `diskImage` config field) must point to a local
+file path. Remote URLs with an `http://` or `https://` scheme — in any letter
+case, e.g. `HTTP://` or `Https://` — are rejected at startup, because the
+underlying [Lima](https://github.com/lima-vm/lima) image-loading path treats the
+value as a local file and would otherwise fail later with a confusing
+"file not found" error.
+
+To use a remote image, download it to a local path first and pass that path to
+`--disk-image`.
 
 ## How can Docker version be updated?
 


### PR DESCRIPTION
## Summary

`ValidateConfig` rejected a `diskImage` starting with `http://` or `https://`, but the scheme match was case-sensitive. Per [RFC 3986 §3.1](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1) URL schemes are case-insensitive, so `HTTP://`, `Https://`, `hTTpS://`, … slipped past validation and failed much later while booting the VM with an opaque `os.Stat` "file not found" instead of the intended "remote URLs not supported" error.

This makes the http/https scheme match case-insensitive and surfaces it through a focused, directly-testable `validateDiskImage` helper, mirroring the existing `validateMounts` / `validateGatewayAddress` helpers (same shape as #1593).

## Root cause

`strings.HasPrefix(c.DiskImage, "http://")` is byte-exact. `HTTP://example.com/img.qcow2` does not start with the lowercase literal, so `ValidateConfig` returned `nil`. The value was then stored as the Lima image `Location` (`environment/vm/lima/disk.go`), and `os.Stat(conf.DiskImage)` failed during `downloadDiskImage` with a generic bootstrap error that gave no hint the *scheme* was the problem — a worse error than the one the validator existed to produce.

## Changes

| File | Change |
| --- | --- |
| `config/configmanager/configmanager.go` | Extract unexported `validateDiskImage(diskImage string) error`; match the http/https scheme case-insensitively via `strings.ToLower`; call it from `ValidateConfig` in place of the old inline block. Error message is unchanged. |
| `config/configmanager/configmanager_test.go` | Add table-driven `TestValidateDiskImage` covering lowercase, uppercase, and mixed-case http/https, empty, local paths, and the non-http(s) boundary (`ftp://`, and a scheme that merely contains "http"). |
| `docs/FAQ.md` | Add a short "Disk image must be a local file" entry noting the http(s) URL rejection (case-insensitive). |

Validation only — `environment/vm/lima/disk.go` and the rest of the runtime path are untouched. Only `http`/`https` are rejected (other schemes are unchanged behavior); the match is made case-insensitive per RFC 3986 §3.1, nothing more.

## Test plan

- [x] `go test ./config/configmanager/... -run TestValidateDiskImage -v` — all subtests pass (lowercase, uppercase, mixed-case http/https rejected; local paths and `ftp://` allowed)
- [x] `go build ./...`
- [x] `golangci-lint run --timeout 3m` (v2.11.3, `0 issues.`)
- [x] `go test ./...`
- [x] Red-before-green + mutation check: the test fails to compile before the helper exists; temporarily reverting the helper to case-sensitive fails the 5 uppercase/mixed-case subtests, confirming the test guards the fix
- [ ] Verify at runtime on macOS/Apple Silicon (out of scope — this PR is validation-only; the downstream `os.Stat`/download path is unchanged and cannot be exercised headlessly)

No linked issue — self-found robustness fix. Precedent: #1593 (`config: reject mount paths containing spaces`).