### PR TITLE
cli: trim whitespace and reject empty dns-host entries

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -287,8 +287,12 @@ func dnsHostsFromFlag(hosts []string) map[string]string {
 			log.Warnf("unable to parse custom dns host: %v, skipping\n", h)
 			continue
 		}
-		src := str[0]
-		target := str[1]
+		src := strings.TrimSpace(str[0])
+		target := strings.TrimSpace(str[1])
+		if src == "" || target == "" {
+			log.Warnf("unable to parse custom dns host: %v, skipping\n", h)
+			continue
+		}
 
 		mapping[src] = target
 	}

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -107,3 +107,75 @@ func Test_withRegistryMirrors(t *testing.T) {
 		})
 	}
 }
+
+func Test_dnsHostsFromFlag(t *testing.T) {
+	tests := []struct {
+		name  string
+		hosts []string
+		want  map[string]string
+	}{
+		{
+			name:  "single valid entry",
+			hosts: []string{"host.docker.internal=192.168.5.1"},
+			want:  map[string]string{"host.docker.internal": "192.168.5.1"},
+		},
+		{
+			name:  "multiple valid entries",
+			hosts: []string{"a.com=1.2.3.4", "b.com=10.0.0.1"},
+			want:  map[string]string{"a.com": "1.2.3.4", "b.com": "10.0.0.1"},
+		},
+		{
+			name:  "whitespace around equals is trimmed",
+			hosts: []string{"myhost = 192.168.1.1"},
+			want:  map[string]string{"myhost": "192.168.1.1"},
+		},
+		{
+			name:  "no equals separator is skipped",
+			hosts: []string{"no-separator-here"},
+			want:  map[string]string{},
+		},
+		{
+			name:  "empty key is skipped",
+			hosts: []string{"=192.168.1.1"},
+			want:  map[string]string{},
+		},
+		{
+			name:  "empty value is skipped",
+			hosts: []string{"myhost="},
+			want:  map[string]string{},
+		},
+		{
+			name:  "whitespace-only key is skipped",
+			hosts: []string{"   =192.168.1.1"},
+			want:  map[string]string{},
+		},
+		{
+			name:  "whitespace-only value is skipped",
+			hosts: []string{"myhost=   "},
+			want:  map[string]string{},
+		},
+		{
+			name:  "valid mixed with invalid",
+			hosts: []string{"good=1.2.3.4", "bad=", "=alsoBad", "spacey = 5.6.7.8"},
+			want:  map[string]string{"good": "1.2.3.4", "spacey": "5.6.7.8"},
+		},
+		{
+			name:  "empty input slice",
+			hosts: []string{},
+			want:  map[string]string{},
+		},
+		{
+			name:  "nil input slice",
+			hosts: nil,
+			want:  map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dnsHostsFromFlag(tt.hosts)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("dnsHostsFromFlag() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`dnsHostsFromFlag` in `cmd/start.go` silently accepted malformed `--dns-host`
entries: surrounding whitespace was preserved (`host = target` → key `"host "`
/ value `" target"`), empty keys were accepted (`=target`), and empty values
were accepted (`host=`). These produced invalid DNS host mappings that
propagated into the Lima resolver configuration and failed at runtime with an
opaque error that gave no hint the flag parsing was the cause.

This trims whitespace on both sides of the `=` split and skips entries whose
key or value is empty after trimming (warn + continue, matching the existing
no-`=` warn-and-skip). Well-formed input is unchanged.

## Root cause

`strings.SplitN(h, "=", 2)` splits on the literal `=` byte but does not strip
surrounding whitespace, and the function had no guard for empty `src` or
`target`. A user writing `--dns-host "myhost = 192.168.1.1"` in a shell (spaces
around `=`) got a DNS entry with a trailing-space key and a leading-space value
— both invalid hostnames/IPs — silently accepted into the config.

## Changes

| File | Change |
| --- | --- |
| `cmd/start.go` | In `dnsHostsFromFlag`: `strings.TrimSpace` on `src` and `target`; skip entries where either is empty after trimming (same `log.Warnf` + `continue` pattern as the existing no-`=` branch). |
| `cmd/start_test.go` | Add table-driven `Test_dnsHostsFromFlag` covering valid entries, whitespace trimming, empty key/value, whitespace-only key/value, no-`=` separator, mixed valid/invalid, and nil/empty input. |

Validation only — no flag declaration changes, no runtime DNS changes, no
`ValidateConfig` changes.

## Test plan

- [x] `go test ./cmd/... -run Test_dnsHostsFromFlag -v` — all 11 subtests pass
- [x] `go build ./...`
- [x] `golangci-lint run --timeout 3m` (v2.12.2)
- [x] `go test ./...`
- [x] Red-before-green + mutation check: test fails on current code; reverting
  the fix after applying it fails the whitespace/empty subtests
- [ ] Verify at runtime on macOS (out of scope — flag parsing only; the
  downstream Lima DNS path is unchanged)

Precedent: #1593 (`config: reject mount paths containing spaces`), #1589
(`cli: add --registry-mirror flag to start command`).