### PR TITLE
dns: fix dnsmasq capability probe to use systemd load state

### DIFF
--- a/environment/vm/lima/dns.go
+++ b/environment/vm/lima/dns.go
@@ -3,6 +3,7 @@ package lima
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/abiosoft/colima/config"
 	"github.com/abiosoft/colima/environment/vm/lima/limautil"
@@ -13,13 +14,41 @@ const (
 	defaultGatewayAddress = "192.168.5.2"
 )
 
-func hasDnsmasq(l *limaVM) bool {
-	// check if dnsmasq is installed
-	return l.RunQuiet("sh", "-c", `apt list | grep 'dnsmasq\/' | grep '\[installed'`) == nil
+// dnsmasqProbe is the minimal package-private seam for the dnsmasq capability
+// probe: it makes the guest command result, stdout, and error observable.
+// *limaVM satisfies it.
+type dnsmasqProbe interface {
+	RunOutput(args ...string) (string, error)
+}
+
+// hasDnsmasq reports whether the guest has a loadable dnsmasq systemd service.
+//
+// It returns (true, nil) when the service is loaded, (false, nil) when the
+// service is absent (not-found), and an error for any other load state or a
+// failed guest command. It intentionally does not parse apt output, which
+// misreports an installed package with an available upgrade.
+func hasDnsmasq(l dnsmasqProbe) (bool, error) {
+	out, err := l.RunOutput("systemctl", "show", "dnsmasq.service", "--property=LoadState", "--value")
+	if err != nil {
+		return false, fmt.Errorf("failed to query dnsmasq service load state: %w", err)
+	}
+
+	switch strings.TrimSpace(out) {
+	case "loaded":
+		return true, nil
+	case "not-found":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected dnsmasq service load state %q", out)
+	}
 }
 
 func (l *limaVM) setupDNS(conf config.Config) error {
-	if !hasDnsmasq(l) {
+	present, err := hasDnsmasq(l)
+	if err != nil {
+		return fmt.Errorf("failed to detect dnsmasq service: %w", err)
+	}
+	if !present {
 		// older image still using systemd-resolved
 		// ignore
 		return nil

--- a/environment/vm/lima/dns_test.go
+++ b/environment/vm/lima/dns_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -226,7 +227,9 @@ func TestAddPostStartActionsSetupDNSFirst(t *testing.T) {
 type fakeHost struct {
 	runOutput func(args ...string) (string, error)
 	runQuiet  func(args ...string) error
+	runWith   func(stdin io.Reader, args ...string) error
 	calls     [][]string
+	written   map[string][]byte
 }
 
 func (f *fakeHost) record(args []string) { f.calls = append(f.calls, args) }
@@ -249,6 +252,24 @@ func (f *fakeHost) RunOutput(args ...string) (string, error) {
 func (f *fakeHost) RunInteractive(args ...string) error { f.record(args); return nil }
 func (f *fakeHost) RunWith(stdin io.Reader, stdout io.Writer, args ...string) error {
 	f.record(args)
+	if f.runWith != nil {
+		return f.runWith(stdin, args...)
+	}
+	if stdin != nil {
+		body, err := io.ReadAll(stdin)
+		if err != nil {
+			return err
+		}
+		if f.written == nil {
+			f.written = map[string][]byte{}
+		}
+		for _, a := range args {
+			if target, ok := strings.CutPrefix(a, "cat > "); ok {
+				f.written[target] = body
+				break
+			}
+		}
+	}
 	return nil
 }
 func (f *fakeHost) Read(fileName string) (string, error) { return "", nil }
@@ -296,5 +317,126 @@ func TestSetupDNSPropagatesCapabilityProbeError(t *testing.T) {
 	}
 	if len(h.calls) != 1 {
 		t.Fatalf("setupDNS() executed %d guest commands; want only the capability probe", len(h.calls))
+	}
+}
+
+// TestSetupDNSRendersCustomGatewayHostnameAndResolvers covers the remaining
+// setupDNS rendering branches: custom gateway address, hostname entry, and
+// explicit DNSResolvers taking precedence over the default gateway server.
+func TestSetupDNSRendersCustomGatewayHostnameAndResolvers(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	gateway := net.ParseIP("10.0.0.2")
+	hostname := "myhost"
+	resolvers := []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("9.9.9.9")}
+	h := &fakeHost{runOutput: func(args ...string) (string, error) {
+		return "loaded", nil
+	}}
+	l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+	conf := config.Config{
+		Hostname: hostname,
+		Network: config.Network{
+			GatewayAddress: gateway,
+			DNSResolvers:   resolvers,
+		},
+	}
+	if err := l.setupDNS(conf); err != nil {
+		t.Fatalf("setupDNS() err = %v; want nil", err)
+	}
+	confOut := string(h.written["/etc/dnsmasq.d/01-colima.conf"])
+	for _, want := range []string{
+		"address=/host.docker.internal/10.0.0.2",
+		"address=/host.lima.internal/10.0.0.2",
+		"address=/myhost/127.0.0.1",
+		"server=1.1.1.1",
+		"server=9.9.9.9",
+	} {
+		if !strings.Contains(confOut, want) {
+			t.Fatalf("dnsmasq config missing %q:\n%s", want, confOut)
+		}
+	}
+	if strings.Contains(confOut, "server=10.0.0.2") {
+		t.Fatalf("dnsmasq config has default gateway server despite explicit resolvers:\n%s", confOut)
+	}
+}
+
+// TestSetupDNSPresentPathPropagatesWriteFailure covers the sequence failure
+// branches: mkdir, dnsmasq config write, resolv.conf removal, and resolv.conf
+// write failures all propagate out of setupDNS.
+func TestSetupDNSPresentPathPropagatesWriteFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		runQuiet func(args ...string) error
+		runWith  func(stdin io.Reader, args ...string) error
+		wantErr  string
+	}{
+		{
+			name: "mkdir fails",
+			runQuiet: func(args ...string) error {
+				for _, a := range args {
+					if a == "mkdir" {
+						return errors.New("mkdir failed")
+					}
+				}
+				return nil
+			},
+			wantErr: "failed to create dnsmasq config directory",
+		},
+		{
+			name: "dnsmasq config write fails",
+			runWith: func(stdin io.Reader, args ...string) error {
+				for _, a := range args {
+					if strings.Contains(a, "01-colima.conf") {
+						return errors.New("write failed")
+					}
+				}
+				return nil
+			},
+			wantErr: "failed to write dnsmasq config",
+		},
+		{
+			name: "resolv.conf removal fails",
+			runQuiet: func(args ...string) error {
+				for _, a := range args {
+					if a == "rm" {
+						return errors.New("rm failed")
+					}
+				}
+				return nil
+			},
+			wantErr: "failed to remove existing resolv.conf",
+		},
+		{
+			name: "resolv.conf write fails",
+			runWith: func(stdin io.Reader, args ...string) error {
+				for _, a := range args {
+					if strings.Contains(a, "resolv.conf") && strings.Contains(a, "cat >") {
+						return errors.New("write failed")
+					}
+				}
+				return nil
+			},
+			wantErr: "failed to write resolv.conf",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PATH", t.TempDir())
+			h := &fakeHost{runOutput: func(args ...string) (string, error) {
+				return "loaded", nil
+			}}
+			h.runQuiet = tt.runQuiet
+			h.runWith = tt.runWith
+			l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+			err := l.setupDNS(config.Config{})
+			if err == nil {
+				t.Fatal("setupDNS() err = nil; want sequence failure")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("setupDNS() err = %v; want it to contain %q", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/environment/vm/lima/dns_test.go
+++ b/environment/vm/lima/dns_test.go
@@ -1,0 +1,300 @@
+package lima
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/abiosoft/colima/cli"
+	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/environment"
+)
+
+// fakeDnsmasqRunner is the minimal package-private seam for the dnsmasq
+// capability probe: it makes command result, stdout, and error observable.
+type fakeDnsmasqRunner struct {
+	out  string
+	err  error
+	args []string
+}
+
+func (f *fakeDnsmasqRunner) RunOutput(args ...string) (string, error) {
+	f.args = append(f.args, args...)
+	return f.out, f.err
+}
+
+func TestDNSMasqCapabilityRejectsUnknownOrMalformedState(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+	}{
+		{name: "empty", out: ""},
+		{name: "whitespace only", out: "   \n\t "},
+		{name: "multiline", out: "loaded\nnot-found"},
+		{name: "unknown state", out: "activating"},
+		{name: "transient state", out: "reloading"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &fakeDnsmasqRunner{out: tt.out}
+			present, err := hasDnsmasq(r)
+			if err == nil {
+				t.Fatalf("hasDnsmasq() = present=%v, err=nil; want error for load state %q", present, tt.out)
+			}
+			if present {
+				t.Fatalf("hasDnsmasq() present=%v; want false for load state %q", present, tt.out)
+			}
+		})
+	}
+}
+
+func TestDNSMasqCapabilityPropagatesCommandFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "transport failure", err: errors.New("connection refused")},
+		{name: "permission failure", err: errors.New("permission denied")},
+		{name: "nonzero exit", err: errors.New("exit status 1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &fakeDnsmasqRunner{err: tt.err}
+			present, err := hasDnsmasq(r)
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("hasDnsmasq() err = %v; want %v", err, tt.err)
+			}
+			if present {
+				t.Fatalf("hasDnsmasq() present = %v; want false", present)
+			}
+		})
+	}
+}
+
+func TestDNSMasqCapabilityIgnoresPackageUpgradePresentation(t *testing.T) {
+	r := &fakeDnsmasqRunner{out: "loaded"}
+	present, err := hasDnsmasq(r)
+	if err != nil {
+		t.Fatalf("hasDnsmasq() err = %v; want nil", err)
+	}
+	if !present {
+		t.Fatal("hasDnsmasq() present = false; want true for loaded service")
+	}
+	want := "systemctl show dnsmasq.service --property=LoadState --value"
+	if got := strings.Join(r.args, " "); got != want {
+		t.Fatalf("probe command = %q; want %q", got, want)
+	}
+}
+
+// TestDNSMasqCapabilityExactStates characterizes the exact tri-state contract:
+// an exact "loaded" state is present, an exact "not-found" state is absent.
+// A guest image with the dnsmasq executable but no loadable service unit
+// (base-only, e.g. dnsmasq-base without the service) still reports not-found,
+// so the probe never treats the binary as capability.
+func TestDNSMasqCapabilityExactStates(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		present bool
+	}{
+		{name: "loaded service is present", out: "loaded", present: true},
+		{name: "not-found service is absent", out: "not-found", present: false},
+		{name: "loaded with trailing newline", out: "loaded\n", present: true},
+		{name: "not-found with trailing whitespace", out: "not-found \n", present: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &fakeDnsmasqRunner{out: tt.out}
+			present, err := hasDnsmasq(r)
+			if err != nil {
+				t.Fatalf("hasDnsmasq() err = %v; want nil", err)
+			}
+			if present != tt.present {
+				t.Fatalf("hasDnsmasq() present = %v; want %v", present, tt.present)
+			}
+		})
+	}
+}
+
+// TestSetupDNSPresentServiceContinuation characterizes the present-service
+// path: a loaded service enters the existing DNS setup sequence, config and
+// resolver writes precede the service restart, and setupDNS returns nil.
+//
+// PATH is emptied so the guest IP acquisition helper fails instantly instead
+// of invoking a real limactl; the helper swallows that error and returns "".
+func TestSetupDNSPresentServiceContinuation(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	h := &fakeHost{runOutput: func(args ...string) (string, error) {
+		return "loaded", nil
+	}}
+	l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+	if err := l.setupDNS(config.Config{}); err != nil {
+		t.Fatalf("setupDNS() err = %v; want nil", err)
+	}
+
+	joined := func(call []string) string { return strings.Join(call, " ") }
+	writeIdx, restartIdx := -1, -1
+	for i, call := range h.calls {
+		s := joined(call)
+		if strings.HasSuffix(s, "sh -c cat > /etc/dnsmasq.d/01-colima.conf") {
+			writeIdx = i
+		}
+		if strings.HasSuffix(s, "systemctl restart dnsmasq") {
+			restartIdx = i
+		}
+	}
+	if writeIdx < 0 {
+		t.Fatalf("setupDNS() did not write dnsmasq config; calls: %v", h.calls)
+	}
+	if restartIdx < 0 {
+		t.Fatalf("setupDNS() did not restart dnsmasq; calls: %v", h.calls)
+	}
+	if writeIdx > restartIdx {
+		t.Fatalf("setupDNS() wrote dnsmasq config after restart (write idx %d, restart idx %d); want config write before restart", writeIdx, restartIdx)
+	}
+
+	wantProbe := "lima systemctl show dnsmasq.service --property=LoadState --value"
+	if got := joined(h.calls[0]); got != wantProbe {
+		t.Fatalf("first command = %q; want probe %q", got, wantProbe)
+	}
+}
+
+// TestSetupDNSPresentPathPropagatesSequenceFailure characterizes the
+// present-service sequence error contract: once the probe reports the service
+// present, a failure in the DNS setup sequence (here the dnsmasq restart)
+// propagates out of setupDNS instead of being silently swallowed.
+func TestSetupDNSPresentPathPropagatesSequenceFailure(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	restartErr := errors.New("systemctl restart failed")
+	h := &fakeHost{
+		runOutput: func(args ...string) (string, error) {
+			return "loaded", nil
+		},
+		runQuiet: func(args ...string) error {
+			if len(args) >= 2 && args[len(args)-2] == "restart" && args[len(args)-1] == "dnsmasq" {
+				return restartErr
+			}
+			return nil
+		},
+	}
+	l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+	err := l.setupDNS(config.Config{})
+	if err == nil {
+		t.Fatal("setupDNS() err = nil; want restart failure")
+	}
+	if !strings.Contains(err.Error(), restartErr.Error()) {
+		t.Fatalf("setupDNS() err = %v; want it to contain %v", err, restartErr)
+	}
+	if !strings.Contains(err.Error(), "failed to restart dnsmasq service") {
+		t.Fatalf("setupDNS() err = %v; want it to contain %q", err, "failed to restart dnsmasq service")
+	}
+}
+
+// TestAddPostStartActionsSetupDNSFirst characterizes post-start ordering
+// (lima.go addPostStartActions): setupDNS is the first post-start action, and
+// its error prevents later post-start actions from running.
+func TestAddPostStartActionsSetupDNSFirst(t *testing.T) {
+	probeErr := errors.New("exit status 1")
+	h := &fakeHost{runOutput: func(args ...string) (string, error) {
+		return "", probeErr
+	}}
+	l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+	a := l.Init(context.Background())
+	l.addPostStartActions(a, config.Config{})
+	err := a.Exec()
+	if err == nil {
+		t.Fatal("Exec() err = nil; want setupDNS error")
+	}
+	if !strings.Contains(err.Error(), "error setting up DNS") {
+		t.Fatalf("Exec() err = %v; want it to contain %q", err, "error setting up DNS")
+	}
+	if len(h.calls) != 1 {
+		t.Fatalf("Exec() ran %d guest commands; want only the capability probe (later post-start actions blocked)", len(h.calls))
+	}
+}
+
+// fakeHost is a package-private fake of environment.HostActions that records
+// every command invocation and lets tests drive the probe result.
+type fakeHost struct {
+	runOutput func(args ...string) (string, error)
+	runQuiet  func(args ...string) error
+	calls     [][]string
+}
+
+func (f *fakeHost) record(args []string) { f.calls = append(f.calls, args) }
+
+func (f *fakeHost) Run(args ...string) error { f.record(args); return nil }
+func (f *fakeHost) RunQuiet(args ...string) error {
+	f.record(args)
+	if f.runQuiet != nil {
+		return f.runQuiet(args...)
+	}
+	return nil
+}
+func (f *fakeHost) RunOutput(args ...string) (string, error) {
+	f.record(args)
+	if f.runOutput != nil {
+		return f.runOutput(args...)
+	}
+	return "", nil
+}
+func (f *fakeHost) RunInteractive(args ...string) error { f.record(args); return nil }
+func (f *fakeHost) RunWith(stdin io.Reader, stdout io.Writer, args ...string) error {
+	f.record(args)
+	return nil
+}
+func (f *fakeHost) Read(fileName string) (string, error) { return "", nil }
+func (f *fakeHost) Write(fileName string, body []byte) error {
+	return nil
+}
+func (f *fakeHost) Stat(fileName string) (os.FileInfo, error) { return nil, nil }
+func (f *fakeHost) WithEnv(env ...string) environment.HostActions {
+	return f
+}
+func (f *fakeHost) WithDir(dir string) environment.HostActions { return f }
+func (f *fakeHost) Env(string) string                          { return "" }
+
+func TestSetupDNSNoopsOnlyWhenServiceIsConfirmedAbsent(t *testing.T) {
+	h := &fakeHost{runOutput: func(args ...string) (string, error) {
+		return "not-found", nil
+	}}
+	l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+	if err := l.setupDNS(config.Config{}); err != nil {
+		t.Fatalf("setupDNS() err = %v; want nil", err)
+	}
+	if len(h.calls) != 1 {
+		t.Fatalf("setupDNS() executed %d guest commands; want only the capability probe", len(h.calls))
+	}
+	want := "lima systemctl show dnsmasq.service --property=LoadState --value"
+	if got := strings.Join(h.calls[0], " "); got != want {
+		t.Fatalf("probe command = %q; want %q", got, want)
+	}
+}
+
+func TestSetupDNSPropagatesCapabilityProbeError(t *testing.T) {
+	probeErr := errors.New("exit status 1")
+	h := &fakeHost{runOutput: func(args ...string) (string, error) {
+		return "", probeErr
+	}}
+	l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+	err := l.setupDNS(config.Config{})
+	if err == nil {
+		t.Fatal("setupDNS() err = nil; want capability probe error")
+	}
+	if !strings.Contains(err.Error(), probeErr.Error()) {
+		t.Fatalf("setupDNS() err = %v; want it to contain %v", err, probeErr)
+	}
+	if len(h.calls) != 1 {
+		t.Fatalf("setupDNS() executed %d guest commands; want only the capability probe", len(h.calls))
+	}
+}

--- a/environment/vm/lima/file.go
+++ b/environment/vm/lima/file.go
@@ -58,7 +58,8 @@ func newFileInfo(guest environment.GuestActions, filename string) (fileInfo, err
 	info.name = filename
 	info.size, _ = strconv.ParseInt(stats[0], 10, 64)
 	info.mode = func() fs.FileMode {
-		mode, _ := strconv.ParseUint(stats[1], 10, 32)
+		// stat -c %a emits an octal mode string (e.g. "644")
+		mode, _ := strconv.ParseUint(stats[1], 8, 32)
 		return fs.FileMode(mode)
 	}()
 	info.modTime = func() time.Time {

--- a/environment/vm/lima/file_test.go
+++ b/environment/vm/lima/file_test.go
@@ -1,0 +1,147 @@
+package lima
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/abiosoft/colima/cli"
+)
+
+// TestWritePropagatesMkdirFailure covers the pre-existing Write helper's
+// mkdir-error branch (file.go): a failed directory creation must surface as
+// an error and no write may follow.
+func TestWritePropagatesMkdirFailure(t *testing.T) {
+	mkdirErr := errors.New("mkdir failed")
+	h := &fakeHost{runQuiet: func(args ...string) error {
+		for _, a := range args {
+			if a == "mkdir" {
+				return mkdirErr
+			}
+		}
+		return nil
+	}}
+	l := &limaVM{host: h, CommandChain: cli.New("vm")}
+
+	err := l.Write("/etc/dnsmasq.d/01-colima.conf", []byte("x"))
+	if !errors.Is(err, mkdirErr) {
+		t.Fatalf("Write() err = %v; want %v", err, mkdirErr)
+	}
+	// no write command may follow a failed mkdir
+	for _, call := range h.calls {
+		if strings.Contains(strings.Join(call, " "), "cat >") {
+			t.Fatalf("Write() ran write after mkdir failure; calls: %v", h.calls)
+		}
+	}
+}
+
+// TestStatNewFileInfo covers the pre-existing Stat/newFileInfo parsing
+// (file.go): size, mode, modtime, isDir, malformed output, and stat failure.
+func TestStatNewFileInfo(t *testing.T) {
+	t.Run("regular file", func(t *testing.T) {
+		h := &fakeHost{runOutput: func(args ...string) (string, error) {
+			return "1234,644,1700000000,regular file", nil
+		}}
+		l := &limaVM{host: h, CommandChain: cli.New("vm")}
+		info, err := l.Stat("/etc/dnsmasq.d/01-colima.conf")
+		if err != nil {
+			t.Fatalf("Stat() err = %v; want nil", err)
+		}
+		if info.Size() != 1234 {
+			t.Fatalf("Size() = %d; want 1234", info.Size())
+		}
+		if info.Mode() != fs.FileMode(0o644) {
+			t.Fatalf("Mode() = %v; want 0644", info.Mode())
+		}
+		if info.IsDir() {
+			t.Fatal("IsDir() = true; want false for regular file")
+		}
+		if want := time.Unix(1700000000, 0); !info.ModTime().Equal(want) {
+			t.Fatalf("ModTime() = %v; want %v", info.ModTime(), want)
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		h := &fakeHost{runOutput: func(args ...string) (string, error) {
+			return "0,755,1700000000,directory", nil
+		}}
+		l := &limaVM{host: h, CommandChain: cli.New("vm")}
+		info, err := l.Stat("/etc/dnsmasq.d")
+		if err != nil {
+			t.Fatalf("Stat() err = %v; want nil", err)
+		}
+		if !info.IsDir() {
+			t.Fatal("IsDir() = false; want true for directory")
+		}
+	})
+
+	t.Run("malformed output", func(t *testing.T) {
+		h := &fakeHost{runOutput: func(args ...string) (string, error) {
+			return "too-few-fields", nil
+		}}
+		l := &limaVM{host: h, CommandChain: cli.New("vm")}
+		if _, err := l.Stat("/etc/dnsmasq.d/01-colima.conf"); err == nil {
+			t.Fatal("Stat() err = nil; want error for malformed stat output")
+		}
+	})
+
+	t.Run("stat failure", func(t *testing.T) {
+		h := &fakeHost{runOutput: func(args ...string) (string, error) {
+			return "", errors.New("stat failed")
+		}}
+		l := &limaVM{host: h, CommandChain: cli.New("vm")}
+		if _, err := l.Stat("/etc/dnsmasq.d/01-colima.conf"); err == nil {
+			t.Fatal("Stat() err = nil; want error")
+		}
+	})
+}
+
+// TestFileInfoSys ensures the fileInfo Sys method stays nil.
+func TestFileInfoSys(t *testing.T) {
+	var f fileInfo
+	if f.Sys() != nil {
+		t.Fatalf("Sys() = %v; want nil", f.Sys())
+	}
+	if f.Name() != "" {
+		t.Fatalf("Name() = %q; want empty", f.Name())
+	}
+}
+
+// silence unused imports in older branches
+var (
+	_ = io.Reader(nil)
+	_ = os.FileInfo(nil)
+)
+
+// TestReadCoversGuestRead covers the pre-existing Read helper (file.go):
+// success returns content, failure propagates the wrapped error.
+func TestReadCoversGuestRead(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		h := &fakeHost{runOutput: func(args ...string) (string, error) {
+			return "content", nil
+		}}
+		l := &limaVM{host: h, CommandChain: cli.New("vm")}
+		got, err := l.Read("/etc/dnsmasq.d/01-colima.conf")
+		if err != nil {
+			t.Fatalf("Read() err = %v; want nil", err)
+		}
+		if got != "content" {
+			t.Fatalf("Read() = %q; want content", got)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		readErr := errors.New("cat failed")
+		h := &fakeHost{runOutput: func(args ...string) (string, error) {
+			return "", readErr
+		}}
+		l := &limaVM{host: h, CommandChain: cli.New("vm")}
+		if _, err := l.Read("/etc/dnsmasq.d/01-colima.conf"); err == nil {
+			t.Fatal("Read() err = nil; want error")
+		}
+	})
+}

--- a/environment/vm/lima/yaml_test.go
+++ b/environment/vm/lima/yaml_test.go
@@ -3,6 +3,7 @@ package lima
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
@@ -100,6 +101,64 @@ func Test_config_Mounts(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewConfResolverCompatibility characterizes the DNS/hostResolver contract
+// preserved by the dnsmasq DNS path: empty DNS keeps the lima hostResolver
+// enabled, explicit resolvers disable it and are preserved in exact order, and
+// DNSHosts are preserved with the host.docker.internal default entry.
+func TestNewConfResolverCompatibility(t *testing.T) {
+	fsutil.FS = fsutil.FakeFS
+
+	t.Run("empty DNS keeps hostResolver enabled", func(t *testing.T) {
+		conf, err := newConf(context.Background(), config.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(conf.DNS) != 0 {
+			t.Fatalf("conf.DNS = %v; want empty", conf.DNS)
+		}
+		if !conf.HostResolver.Enabled {
+			t.Fatal("conf.HostResolver.Enabled = false; want true with empty DNS")
+		}
+		if got := conf.HostResolver.Hosts["host.docker.internal"]; got != "host.lima.internal" {
+			t.Fatalf("host.docker.internal = %q; want %q", got, "host.lima.internal")
+		}
+	})
+
+	t.Run("explicit resolvers preserved in order", func(t *testing.T) {
+		resolvers := []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("8.8.8.8")}
+		conf, err := newConf(context.Background(), config.Config{Network: config.Network{DNSResolvers: resolvers}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(conf.DNS) != 2 {
+			t.Fatalf("conf.DNS = %v; want two resolvers", conf.DNS)
+		}
+		if got := conf.DNS[0].String(); got != "1.1.1.1" {
+			t.Fatalf("conf.DNS[0] = %q; want %q", got, "1.1.1.1")
+		}
+		if got := conf.DNS[1].String(); got != "8.8.8.8" {
+			t.Fatalf("conf.DNS[1] = %q; want %q", got, "8.8.8.8")
+		}
+		if conf.HostResolver.Enabled {
+			t.Fatal("conf.HostResolver.Enabled = true; want false with explicit resolvers")
+		}
+	})
+
+	t.Run("DNSHosts preserved with default entry", func(t *testing.T) {
+		hosts := map[string]string{"custom.internal": "10.0.0.5"}
+		conf, err := newConf(context.Background(), config.Config{Network: config.Network{DNSHosts: hosts}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := conf.HostResolver.Hosts["custom.internal"]; got != "10.0.0.5" {
+			t.Fatalf("custom.internal = %q; want %q", got, "10.0.0.5")
+		}
+		if got := conf.HostResolver.Hosts["host.docker.internal"]; got != "host.lima.internal" {
+			t.Fatalf("host.docker.internal = %q; want %q", got, "host.lima.internal")
+		}
+	})
 }
 
 func Test_ingressDisabled(t *testing.T) {


### PR DESCRIPTION
## Summary

On macOS, `setupDNS` misdetects a fully installed, systemd-loadable `dnsmasq.service` as absent when the installed package has an available upgrade: the old `apt list` probe pipeline exits nonzero, `setupDNS` skips DNS regeneration, dnsmasq stays bound to a stale guest address after a guest-IP change, and container DNS times out (`lookup registry-1.docker.io ... i/o timeout`).

Reproduced and fixed on macOS arm64 (VZ, user-v2, Docker). The fix lives in guest-side code shared with Linux, so Linux-hosted colima inherits the correction; a Linux/QEMU integration run confirms no regression (no Linux-host bug was separately reproduced).

## Fix

Tri-state probe via systemd load state (`dns.go`):

```sh
systemctl show dnsmasq.service --property=LoadState --value
```

- `loaded` → present, run setup sequence
- `not-found` → absent, no-op
- other state / command failure → error, propagated through `setupDNS`

The exported `limautil.InternalIPAddress` contract is untouched; `dns.go` stops importing it only in the strict-IP follow-up (Patch 2).

## Tests

RED-first (`dns_test.go`): probe states (unknown/malformed/transient, command failures, upgrade presentation, exact loaded/not-found), setupDNS gate (no-op on not-found, probe-error stop), present-service continuation (write-before-restart), post-start ordering, sequence failure propagation, rendering branches (custom gateway, hostname, explicit resolver precedence, write failures). Resolver/hostResolver compat (`yaml_test.go`): empty DNS keeps hostResolver enabled; explicit resolvers disable it and preserve order; DNSHosts preserved with default entry. File helpers (`file_test.go`): Read/Write/Stat/newFileInfo characterization.

Coverage exposed a latent bug in the pre-existing `newFileInfo`: the octal mode string from `stat -c %a` was parsed as base 10, so `Mode()` returned 0644 as 0o1204. Fixed to base 8 (`file.go`).

`go test -count=1 ./...`, `-race`, gofmt/vet clean.

## Scope

Patch 1 only. Strict IP acquisition (P2), atomic transaction (P3), health checks (P4) are separate follow-ups on stacked branches.

## Related issue

Umbrella: #711 (one reproducible post-#1381 cause, not all of #711).

## Review guide

- `dns.go`: `hasDnsmasq` probe + `setupDNS` gate
- `dns_test.go`: seam via `dnsmasqProbe`/`fakeHost`
- `yaml_test.go`: resolver/hostResolver compatibility
- `file.go` + `file_test.go`: pre-existing guest file helpers (octal mode parse fix + coverage)
- Only `dns.go`, `file.go` + tests changed; `limautil` untouched

## LLM usage disclosure

Code and tests generated with LLM assistance, human reviewed.