### PR TITLE
cli: honor mount writable suffix case-insensitively

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -325,11 +325,11 @@ func mountsFromFlag(mounts []string) []config.Mount {
 		if len(str) > 1 {
 			if filepath.IsAbs(str[1]) {
 				mnt.MountPoint = str[1]
-			} else if str[1] == "w" {
+			} else if strings.EqualFold(str[1], "w") {
 				mnt.Writable = true
 			}
 		}
-		if len(str) > 2 && str[2] == "w" {
+		if len(str) > 2 && strings.EqualFold(str[2], "w") {
 			mnt.Writable = true
 		}
 

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -23,6 +23,14 @@ func Test_mountsFromFlag(t *testing.T) {
 		},
 		{
 			mounts: []string{
+				"~:W",
+			},
+			want: []config.Mount{
+				{Location: "~", Writable: true},
+			},
+		},
+		{
+			mounts: []string{
 				"~",
 			},
 			want: []config.Mount{
@@ -48,6 +56,14 @@ func Test_mountsFromFlag(t *testing.T) {
 				{Location: "/home/another", Writable: true},
 				{Location: "/tmp", MountPoint: "/users/tmp"},
 				{Location: "/tmp", MountPoint: "/users/tmp", Writable: true},
+			},
+		},
+		{
+			mounts: []string{
+				"/home/users:/home/users:W",
+			},
+			want: []config.Mount{
+				{Location: "/home/users", MountPoint: "/home/users", Writable: true},
 			},
 		},
 		{


### PR DESCRIPTION
`colima start --mount /dir:W` (and `/dir:/mountpoint:W`) silently dropped the writable flag when the suffix was uppercase. `mountsFromFlag` already checked the `none` sentinel case-insensitively (`strings.ToLower`), but the writable suffix used exact equality (`str[1] == "w"` / `str[2] == "w"`), so `:W` matched neither branch and Lima received a read-only mount with no warning — the user's stated intent was silently not honored. Inconsistent with the same function's `none` handling and with the case-insensitive diskImage-scheme fix in #1615.

## Fix
Use `strings.EqualFold(…, "w")` for both writable-suffix checks, mirroring the case-insensitive `none` sentinel. ~2-line behavior change; `strings` is already imported. Different file from #1615 (diskImage) and #1616 (dns-host).

## Test plan
`go test ./cmd/...` — green, including two new table rows in `Test_mountsFromFlag`: `~:W` → `Writable:true` (was `false`) and `/home/users:/home/users:W` → `Writable:true` (was `false`).