### PR TITLE
fix: correct Retry attempt count and retryCount sequence

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -150,12 +150,17 @@ func (a *ActiveCommandChain) Exec() error {
 // retryCount starts from 1.
 func (a *ActiveCommandChain) Retry(stage string, interval time.Duration, count int, f func(retryCount int) error) {
 	a.Add(func() (err error) {
-		var i int
-		for err = f(i + 1); i < count && err != nil; i, err = i+1, f(i+1) {
-			if stage != "" {
-				a.log.Println(stage, "...")
+		for i := 0; i < count; i++ {
+			if err = f(i + 1); err == nil {
+				return nil
 			}
-			time.Sleep(interval)
+			// back off before the next attempt; skip the sleep after the final attempt
+			if i < count-1 {
+				if stage != "" {
+					a.log.Println(stage, "...")
+				}
+				time.Sleep(interval)
+			}
 		}
 		return err
 	})

--- a/cli/chain_test.go
+++ b/cli/chain_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// quietChain returns an ActiveCommandChain whose logger discards output, keeping tests silent.
+func quietChain() *ActiveCommandChain {
+	ctx := context.WithValue(context.Background(), CtxKeyQuiet, true)
+	return New("test").Init(ctx)
+}
+
+func TestRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		// count is the requested number of attempts.
+		count int
+		// fail reports whether f should error for the given retryCount (1-based).
+		// Returning false makes f succeed, stopping further attempts.
+		fail func(retryCount int) bool
+		// wantCalls is the exact number of times f must be invoked.
+		wantCalls int
+		// wantRetryCount is the exact 1-based retryCount sequence f must observe.
+		wantRetryCount []int
+		// wantErr is "" when Exec must return nil, otherwise the expected last error message.
+		wantErr string
+	}{
+		{
+			name:           "all attempts fail",
+			count:          3,
+			fail:           func(int) bool { return true },
+			wantCalls:      3,
+			wantRetryCount: []int{1, 2, 3},
+			wantErr:        "failed at retryCount 3",
+		},
+		{
+			name:           "single attempt fails",
+			count:          1,
+			fail:           func(int) bool { return true },
+			wantCalls:      1,
+			wantRetryCount: []int{1},
+			wantErr:        "failed at retryCount 1",
+		},
+		{
+			name:           "succeeds on first attempt",
+			count:          4,
+			fail:           func(int) bool { return false },
+			wantCalls:      1,
+			wantRetryCount: []int{1},
+			wantErr:        "",
+		},
+		{
+			name:           "succeeds on second attempt",
+			count:          5,
+			fail:           func(retryCount int) bool { return retryCount < 2 },
+			wantCalls:      2,
+			wantRetryCount: []int{1, 2},
+			wantErr:        "",
+		},
+		{
+			name:           "succeeds on final attempt",
+			count:          3,
+			fail:           func(retryCount int) bool { return retryCount < 3 },
+			wantCalls:      3,
+			wantRetryCount: []int{1, 2, 3},
+			wantErr:        "",
+		},
+		{
+			name:           "zero attempts when count is zero",
+			count:          0,
+			fail:           func(int) bool { return true },
+			wantCalls:      0,
+			wantRetryCount: nil,
+			wantErr:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				calls      int
+				retryCount []int
+			)
+
+			active := quietChain()
+			active.Retry("", time.Millisecond, tt.count, func(rc int) error {
+				calls++
+				retryCount = append(retryCount, rc)
+				if tt.fail(rc) {
+					return fmt.Errorf("failed at retryCount %d", rc)
+				}
+				return nil
+			})
+
+			err := active.Exec()
+
+			if calls != tt.wantCalls {
+				t.Errorf("f invoked %d time(s), want %d", calls, tt.wantCalls)
+			}
+			if !reflect.DeepEqual(retryCount, tt.wantRetryCount) {
+				t.Errorf("retryCount sequence = %v, want %v", retryCount, tt.wantRetryCount)
+			}
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+			if gotErr != tt.wantErr {
+				t.Errorf("Exec() error = %q, want %q", gotErr, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# PR title

`fix: correct Retry attempt count and retryCount sequence`

# Body

`ActiveCommandChain.Retry` runs one more attempt than requested and passes a duplicated first `retryCount` to the callback. This fixes it so `Retry(stage, interval, count, f)` invokes `f` exactly `count` times with `retryCount` `1..count`, returns `nil` on the first success, and otherwise returns the last error — matching the function's own doc comment.

## Root cause

In `cli/chain.go`, the loop seeded the callback in **both** the `for` init and post clauses:

```go
var i int
for err = f(i + 1); i < count && err != nil; i, err = i+1, f(i+1) {
    ...
}
```

Two things go wrong:

1. `f` is called once in the init clause (`f(i+1)`) **and** again at the end of every iteration (the post clause `f(i+1)`), so `f` runs `count+1` times instead of `count`.
2. In the post assignment `i, err = i+1, f(i+1)`, Go evaluates the whole right-hand side before assigning, so `f(i+1)` sees the **pre-increment** `i`. On the first pass `i` is still `0`, so it calls `f(1)` again — the `retryCount=1` call is duplicated.

Net effect for `count=3` (all attempts failing): `f` is called **4 times** with the sequence `1, 1, 2, 3` instead of `1, 2, 3`. Because the init clause is unconditional, `count=0` still calls `f(1)` once. The doc comment (“retries `f` up to `count` times”, “after `count` attempts”, “`retryCount` starts from 1”) promises exactly `count` attempts.

## Changes

- **`cli/chain.go`** — replace the loop with a plain counter that calls `f` exactly `count` times with `retryCount` `1..count`, returns early on the first `nil` error, and keeps the inter-attempt backoff (log + `time.Sleep(interval)` between attempts, none after the last, as before). Signature, callers, and sleep semantics are unchanged.
- **`cli/chain_test.go`** (new) — `TestRetry`, a table-driven test (mirrors `config/configmanager/configmanager_test.go`) asserting the exact call count, the `retryCount` sequence, and the returned error/nil across: all-fail, single-attempt-fail, first-attempt-success, second-attempt-success, final-attempt-success, and `count=0`.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run --timeout 3m` (0 issues; v2.x)
- [x] `go test ./cli/` — `TestRetry` red against the old loop (`[1 1 2 3]` for `count=3`), green after the fix
- [x] `go test ./...` — all packages pass
- [x] Verified no other `cli/` files change; 8 `Retry` call sites unchanged

`Retry` is a pure chain helper with no OS/runtime dependency, so this is fully exercised by the unit test on both halves of the CI matrix (linux + macOS); no `colima start`/VM path is involved.
