### PR TITLE
Add configurable data disk filesystem

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -67,10 +67,17 @@ Run 'colima template' to set the default configurations or 'colima start --edit'
 		if err != nil {
 			return err
 		}
+		setConfigDefaults(&conf)
+		setFixedConfigs(&conf)
 
 		// validate config
 		if err := configmanager.ValidateConfig(conf); err != nil {
 			return fmt.Errorf("error in config file: %w", err)
+		}
+		if startCmdArgs.Flags.SaveConfig {
+			if err := configmanager.Save(conf); err != nil {
+				return fmt.Errorf("error preparing config file: %w", err)
+			}
 		}
 
 		if app.Active() {
@@ -124,6 +131,7 @@ const (
 	defaultCPU               = 2
 	defaultMemory            = 2
 	defaultDisk              = 100
+	defaultDiskFS            = "ext4"
 	defaultRootDisk          = 20
 	defaultKubernetesVersion = kubernetes.DefaultVersion
 
@@ -189,6 +197,7 @@ func init() {
 	startCmd.Flags().StringVar(&startCmdArgs.CPUType, "cpu-type", "", "the CPU type, options can be checked with 'qemu-system-"+defaultArch+" -cpu help'")
 	startCmd.Flags().Float32VarP(&startCmdArgs.Memory, "memory", "m", defaultMemory, "memory in GiB")
 	startCmd.Flags().IntVarP(&startCmdArgs.Disk, "disk", "d", defaultDisk, "disk size in GiB")
+	startCmd.Flags().StringVar(&startCmdArgs.DiskFS, "disk-fs", defaultDiskFS, "filesystem for the container data disk, fixed after initial creation (ext4, xfs)")
 	startCmd.Flags().IntVar(&startCmdArgs.RootDisk, "root-disk", defaultRootDisk, "disk size in GiB for the root filesystem")
 	startCmd.Flags().StringVarP(&startCmdArgs.Arch, "arch", "a", defaultArch, "architecture (aarch64, x86_64)")
 	startCmd.Flags().BoolVarP(&startCmdArgs.Flags.Foreground, "foreground", "f", false, "Keep colima in the foreground")
@@ -396,6 +405,10 @@ func setFlagDefaults(cmd *cobra.Command) {
 }
 
 func setConfigDefaults(conf *config.Config) {
+	if conf.DiskFS == "" {
+		conf.DiskFS = defaultDiskFS
+	}
+
 	// handle macOS virtualization.framework transition
 	if conf.VMType == "" {
 		conf.VMType = defaultVMType
@@ -434,7 +447,7 @@ func setFixedConfigs(conf *config.Config) {
 	}
 
 	// override the fixed configs
-	// arch, vmType, mountType, runtime are fixed and cannot be changed
+	// arch, vmType, mountType, runtime and diskFS are fixed and cannot be changed
 	if fixedConf.Arch != "" {
 		warnIfNotEqual("architecture", conf.Arch, fixedConf.Arch)
 		conf.Arch = fixedConf.Arch
@@ -447,6 +460,13 @@ func setFixedConfigs(conf *config.Config) {
 		warnIfNotEqual("runtime", conf.Runtime, fixedConf.Runtime)
 		conf.Runtime = fixedConf.Runtime
 	}
+	fixedDiskFS := fixedConf.DiskFS
+	if fixedDiskFS == "" {
+		// profiles created before diskFS was configurable always used ext4
+		fixedDiskFS = defaultDiskFS
+	}
+	warnIfNotEqual("disk filesystem", conf.DiskFS, fixedDiskFS)
+	conf.DiskFS = fixedDiskFS
 	if fixedConf.MountType != "" {
 		warnIfNotEqual("volume mount type", conf.MountType, fixedConf.MountType)
 		conf.MountType = fixedConf.MountType
@@ -536,6 +556,9 @@ func prepareConfig(cmd *cobra.Command) {
 	}
 	if !cmd.Flag("disk").Changed {
 		startCmdArgs.Disk = current.Disk
+	}
+	if !cmd.Flag("disk-fs").Changed {
+		startCmdArgs.DiskFS = current.DiskFS
 	}
 	if !cmd.Flag("root-disk").Changed {
 		if current.RootDisk > 0 {
@@ -690,11 +713,6 @@ func editConfigFile() (config.Config, error) {
 	defer func() {
 		_ = os.Remove(tmpFile)
 	}()
-	if startCmdArgs.Flags.SaveConfig {
-		if err := configmanager.SaveFromFile(tmpFile); err != nil {
-			return c, err
-		}
-	}
 	return configmanager.LoadFrom(tmpFile)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ var (
 type Config struct {
 	CPU      int               `yaml:"cpu,omitempty"`
 	Disk     int               `yaml:"disk,omitempty"`
+	DiskFS   string            `yaml:"diskFS,omitempty"`
 	RootDisk int               `yaml:"rootDisk,omitempty"`
 	Memory   float32           `yaml:"memory,omitempty"`
 	Arch     string            `yaml:"arch,omitempty"`

--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -52,6 +52,10 @@ func ValidateConfig(c config.Config) error {
 	validMountTypes := map[string]bool{"9p": true, "sshfs": true}
 	validPortForwarders := map[string]bool{"grpc": true, "ssh": true, "none": true}
 
+	if err := validateDiskFilesystem(c.DiskFS); err != nil {
+		return err
+	}
+
 	if util.MacOS13OrNewer() {
 		validMountTypes["virtiofs"] = true
 	}
@@ -102,6 +106,16 @@ func ValidateConfig(c config.Config) error {
 		return err
 	}
 
+	return nil
+}
+
+func validateDiskFilesystem(fsType string) error {
+	if fsType != "ext4" && fsType != "xfs" {
+		return fmt.Errorf("invalid diskFS: '%s'", fsType)
+	}
+	if fsType == "xfs" && len("lima-"+config.CurrentProfile().ID) > 12 {
+		return fmt.Errorf("diskFS 'xfs' is not supported for profile '%s' because the generated filesystem label exceeds 12 bytes", config.CurrentProfile().ShortName)
+	}
 	return nil
 }
 

--- a/config/configmanager/configmanager_test.go
+++ b/config/configmanager/configmanager_test.go
@@ -1,10 +1,41 @@
 package configmanager
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/abiosoft/colima/config"
 )
+
+func TestValidateDiskFilesystem(t *testing.T) {
+	config.SetProfile("default")
+	t.Cleanup(func() { config.SetProfile("default") })
+
+	tests := []struct {
+		name    string
+		profile string
+		fsType  string
+		wantErr string
+	}{
+		{name: "ext4", profile: "default", fsType: "ext4"},
+		{name: "xfs", profile: "default", fsType: "xfs"},
+		{name: "unsupported", profile: "default", fsType: "btrfs", wantErr: "invalid diskFS"},
+		{name: "xfs custom profile", profile: "custom", fsType: "xfs", wantErr: "generated filesystem label exceeds 12 bytes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.SetProfile(tt.profile)
+			err := validateDiskFilesystem(tt.fsType)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("validateDiskFilesystem() error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("validateDiskFilesystem() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestValidateMounts(t *testing.T) {
 	tests := []struct {

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -8,6 +8,14 @@ cpu: 2
 # Default: 100
 disk: 100
 
+# Filesystem for the disk containing container data (ext4, xfs).
+# NOTE: this cannot be changed after the virtual machine is created.
+# XFS is currently only supported for the default profile. Lima derives the
+# filesystem label as "lima-<disk-name>", which exceeds XFS's 12-byte label
+# limit for Colima's custom-profile disk names.
+# Default: ext4
+diskFS: ext4
+
 # Size of the memory in GiB to be allocated to the virtual machine.
 # Default: 2
 memory: 2

--- a/environment/container/containerd/containerd.go
+++ b/environment/container/containerd/containerd.go
@@ -187,8 +187,7 @@ func (c *containerdRuntime) Update(ctx context.Context) (bool, error) {
 // DataDirs represents the data disk for the container runtime.
 func DataDisk() environment.DataDisk {
 	return environment.DataDisk{
-		Dirs:   diskDirs,
-		FSType: "ext4",
+		Dirs: diskDirs,
 		PreMount: []string{
 			"systemctl stop containerd.service",
 			"systemctl stop buildkit.service",

--- a/environment/container/docker/docker.go
+++ b/environment/container/docker/docker.go
@@ -157,8 +157,7 @@ func (d *dockerRuntime) Update(ctx context.Context) (bool, error) {
 // DataDirs represents the data disk for the container runtime.
 func DataDisk() environment.DataDisk {
 	return environment.DataDisk{
-		Dirs:   diskDirs,
-		FSType: "ext4",
+		Dirs: diskDirs,
 		PreMount: []string{
 			"systemctl stop docker.service",
 			"systemctl stop containerd.service",

--- a/environment/container/incus/incus.go
+++ b/environment/container/incus/incus.go
@@ -514,7 +514,6 @@ fi`
 // DataDisk represents the data disk for the container runtime.
 func DataDisk() environment.DataDisk {
 	return environment.DataDisk{
-		FSType: "ext4",
 		Dirs: []environment.DiskDir{
 			{Name: "incus", Path: "/var/lib/incus"},
 		},

--- a/environment/vm/lima/disk.go
+++ b/environment/vm/lima/disk.go
@@ -30,7 +30,7 @@ func (l *limaVM) createRuntimeDisk(conf config.Config) error {
 		return nil
 	}
 
-	disk := dataDisk(conf.Runtime)
+	disk := dataDisk(conf)
 
 	s, _ := store.Load()
 	format := !s.DiskFormatted // only format if not previously formatted
@@ -54,7 +54,7 @@ func (l *limaVM) createRuntimeDisk(conf config.Config) error {
 		FSType: disk.FSType,
 	})
 
-	l.mountRuntimeDisk(conf, format)
+	l.mountRuntimeDisk(disk, format)
 	return nil
 }
 
@@ -64,7 +64,7 @@ func (l *limaVM) useRuntimeDisk(conf config.Config) {
 		return
 	}
 
-	disk := dataDisk(conf.Runtime)
+	disk := dataDisk(conf)
 
 	s, _ := store.Load()
 	format := !s.DiskFormatted // only format if not previously formatted
@@ -76,28 +76,33 @@ func (l *limaVM) useRuntimeDisk(conf config.Config) {
 		FSType: disk.FSType,
 	})
 
-	l.mountRuntimeDisk(conf, format)
+	l.mountRuntimeDisk(disk, format)
 }
 
-func dataDisk(runtime string) environment.DataDisk {
-	switch runtime {
+func dataDisk(conf config.Config) environment.DataDisk {
+	var disk environment.DataDisk
+
+	switch conf.Runtime {
 	case docker.Name:
-		return docker.DataDisk()
+		disk = docker.DataDisk()
 	case containerd.Name:
-		return containerd.DataDisk()
+		disk = containerd.DataDisk()
 	case incus.Name:
-		return incus.DataDisk()
+		disk = incus.DataDisk()
 	}
 
-	return environment.DataDisk{}
+	disk.FSType = conf.DiskFS
+	return disk
 }
 
-func diskMountScript(format bool) string {
+func diskMountScript(format bool, fsType string) string {
 	var values = struct {
 		Format     bool
+		FSType     string
 		InstanceId string
 	}{
 		Format:     format,
+		FSType:     fsType,
 		InstanceId: config.CurrentProfile().ID,
 	}
 
@@ -109,16 +114,14 @@ func diskMountScript(format bool) string {
 	return string(b)
 }
 
-func (l *limaVM) mountRuntimeDisk(conf config.Config, format bool) {
+func (l *limaVM) mountRuntimeDisk(disk environment.DataDisk, format bool) {
 	// provision script to prepare disk
 	l.limaConf.Provision = append(l.limaConf.Provision, limaconfig.Provision{
 		Mode:   "dependency",
-		Script: diskMountScript(format),
+		Script: diskMountScript(format, disk.FSType),
 	})
 
 	// handle disk mounts
-	disk := dataDisk(conf.Runtime)
-
 	// pre mount script
 	for _, script := range disk.PreMount {
 		l.limaConf.Provision = append(l.limaConf.Provision, limaconfig.Provision{

--- a/environment/vm/lima/disk.sh
+++ b/environment/vm/lima/disk.sh
@@ -3,11 +3,12 @@
 # Steps:
 # 1. Check if directory is already mounted, if yes, skip setup
 # 2. Idenify disk e.g. /dev/vdb or /dev/vdc
-# 3. Format disk with ext4 if not already formatted
+# 3. Format disk if not already formatted
 # 4. Label disk with instance id
 # 5. Mount disk
 
 DISK_LABEL="lima-{{ .InstanceId }}"
+DISK_FS="{{ .FSType }}"
 MOUNT_POINT="/mnt/${DISK_LABEL}"
 
 # Detect the disk to use e.g. /dev/vdb or /dev/vdc
@@ -16,6 +17,13 @@ if df -h /mnt/lima-cidata/ | tail -n +2 | grep '^/dev/vdb'; then
 	DISK="/dev/vdc"
 fi
 DISK_PART="${DISK}1"
+
+# Refuse to reinterpret an existing disk using a different filesystem.
+ACTUAL_FS="$(blkid --output value --match-tag TYPE "$DISK_PART" 2>/dev/null || true)"
+if [ -n "$ACTUAL_FS" ] && [ "$ACTUAL_FS" != "$DISK_FS" ]; then
+	echo "Disk is formatted with $ACTUAL_FS, but diskFS is configured as $DISK_FS."
+	exit 1
+fi
 
 # Check current mount state before touching the disk.
 if findmnt --noheadings --source "$DISK_PART" --target "$MOUNT_POINT" >/dev/null 2>&1; then
@@ -30,10 +38,9 @@ fi
 
 {{ if .Format }}
 echo 'type=83' | sudo sfdisk "$DISK"
-mkfs.ext4 "$DISK_PART"
-e2label "$DISK_PART" "$DISK_LABEL"
+mkfs -t "$DISK_FS" -L "$DISK_LABEL" "$DISK_PART"
 {{ end }}
 
 # mount disk
 mkdir -p "$MOUNT_POINT"
-mount "$DISK_PART" "$MOUNT_POINT"
+mount -t "$DISK_FS" "$DISK_PART" "$MOUNT_POINT"

--- a/environment/vm/lima/disk_test.go
+++ b/environment/vm/lima/disk_test.go
@@ -1,0 +1,43 @@
+package lima
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/abiosoft/colima/config"
+	"github.com/abiosoft/colima/environment/vm/lima/limautil"
+)
+
+func TestDiskMountScriptFilesystem(t *testing.T) {
+	script := diskMountScript(true, "xfs")
+
+	for _, expected := range []string{
+		`DISK_FS="xfs"`,
+		`[ "$ACTUAL_FS" != "$DISK_FS" ]`,
+		`mkfs -t "$DISK_FS" -L "$DISK_LABEL" "$DISK_PART"`,
+		`mount -t "$DISK_FS" "$DISK_PART" "$MOUNT_POINT"`,
+	} {
+		if !strings.Contains(script, expected) {
+			t.Errorf("diskMountScript() does not contain %q", expected)
+		}
+	}
+}
+
+func TestDiskResizeScript(t *testing.T) {
+	instanceID := config.CurrentProfile().ID
+	tests := []struct {
+		fsType string
+		want   string
+	}{
+		{fsType: "ext4", want: "resize2fs " + diskByLabelPath(instanceID) + " || true"},
+		{fsType: "xfs", want: "xfs_growfs " + limautil.MountPoint() + " || true"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fsType, func(t *testing.T) {
+			if got := diskResizeScript(tt.fsType, instanceID); got != tt.want {
+				t.Errorf("diskResizeScript() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/environment/vm/lima/yaml.go
+++ b/environment/vm/lima/yaml.go
@@ -372,7 +372,7 @@ func newConf(ctx context.Context, conf config.Config) (l limaconfig.Config, err 
 	// grow partition in case disk size has increased
 	l.Provision = append(l.Provision, limaconfig.Provision{
 		Mode:   limaconfig.ProvisionModeSystem,
-		Script: "resize2fs " + diskByLabelPath(config.CurrentProfile().ID) + " || true",
+		Script: diskResizeScript(conf.DiskFS, config.CurrentProfile().ID),
 	})
 
 	/* end */
@@ -481,4 +481,15 @@ func diskByLabelPath(instanceId string) string {
 	}
 
 	return "/dev/disk/by-label/" + name
+}
+
+func diskResizeScript(fsType, instanceId string) string {
+	switch fsType {
+	case "xfs":
+		// xfs_growfs operates on the mounted filesystem.
+		return "xfs_growfs " + limautil.MountPoint() + " || true"
+	default:
+		// resize2fs operates on the ext4 block device.
+		return "resize2fs " + diskByLabelPath(instanceId) + " || true"
+	}
 }


### PR DESCRIPTION
Add a new `diskFS` config option for the VM data disk, defaulting to `ext4` and validating allowed values (`ext4`, `xfs`). 

- Preserve the value in profile defaults and reject unsupported changes after creation
- XFS is limited to profiles whose generated labels fit within the 12-byte Linux limit (which basically means the default profile only, for now, due to label name generation)
- Mount and resize scripts now format and mount the correct filesystem and refuse to reinterpret an existing disk with a different filesystem. 
 
This also updates the default template and adds coverage for disk validation and mount/resize behavior.

See related https://github.com/abiosoft/colima-core/pull/20

Closes #1624 
