### PR TITLE
net: add configurable subnet for shared networking

### DIFF
--- a/cmd/daemon/cmd.go
+++ b/cmd/daemon/cmd.go
@@ -32,7 +32,7 @@ var startCmd = &cobra.Command{
 
 		var processes []process.Process
 		if daemonArgs.vmnet.enabled {
-			processes = append(processes, vmnet.New(daemonArgs.vmnet.mode, daemonArgs.vmnet.netInterface))
+			processes = append(processes, vmnet.New(daemonArgs.vmnet.mode, daemonArgs.vmnet.netInterface, daemonArgs.vmnet.subnet))
 		}
 		if daemonArgs.inotify.enabled {
 			processes = append(processes, inotify.New())
@@ -83,6 +83,7 @@ var daemonArgs struct {
 		enabled      bool
 		mode         string
 		netInterface string
+		subnet       vmnet.Subnet
 	}
 	inotify struct {
 		enabled bool
@@ -103,6 +104,9 @@ func init() {
 	startCmd.Flags().BoolVar(&daemonArgs.vmnet.enabled, "vmnet", false, "start vmnet")
 	startCmd.Flags().StringVar(&daemonArgs.vmnet.mode, "vmnet-mode", "shared", "vmnet mode (shared, bridged)")
 	startCmd.Flags().StringVar(&daemonArgs.vmnet.netInterface, "vmnet-interface", "en0", "vmnet interface for bridged mode")
+	startCmd.Flags().StringVar(&daemonArgs.vmnet.subnet.Gateway, "vmnet-gateway", vmnet.NetGateway, "vmnet gateway for shared mode")
+	startCmd.Flags().StringVar(&daemonArgs.vmnet.subnet.DHCPEnd, "vmnet-dhcp-end", vmnet.NetDHCPEnd, "vmnet DHCP end address for shared mode")
+	startCmd.Flags().StringVar(&daemonArgs.vmnet.subnet.Netmask, "vmnet-mask", vmnet.NetMask, "vmnet mask for shared mode")
 	startCmd.Flags().BoolVar(&daemonArgs.inotify.enabled, "inotify", false, "start inotify")
 	startCmd.Flags().StringSliceVar(&daemonArgs.inotify.dirs, "inotify-dir", nil, "set inotify directories")
 	startCmd.Flags().StringVar(&daemonArgs.inotify.runtime, "inotify-runtime", "docker", "set runtime")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -214,6 +214,7 @@ func init() {
 		// network address
 		startCmd.Flags().BoolVar(&startCmdArgs.Network.Address, "network-address", false, "assign reachable IP address to the VM")
 		startCmd.Flags().StringVar(&startCmdArgs.Network.Mode, "network-mode", "shared", "network mode (shared, bridged)")
+		startCmd.Flags().StringVar(&startCmdArgs.Network.Subnet, "network-subnet", "", "subnet for shared mode (e.g. 192.168.107.0/24)")
 		startCmd.Flags().StringVar(&startCmdArgs.Network.BridgeInterface, "network-interface", "en0", "host network interface to use for bridged mode")
 		startCmd.Flags().BoolVar(&startCmdArgs.Network.PreferredRoute, "network-preferred-route", false, "use the assigned IP address as the preferred route for the VM (implies --network-address)")
 
@@ -634,6 +635,9 @@ func prepareConfig(cmd *cobra.Command) {
 		}
 		if !cmd.Flag("network-mode").Changed {
 			startCmdArgs.Network.Mode = current.Network.Mode
+		}
+		if !cmd.Flag("network-subnet").Changed {
+			startCmdArgs.Network.Subnet = current.Network.Subnet
 		}
 		if !cmd.Flag("network-interface").Changed {
 			startCmdArgs.Network.BridgeInterface = current.Network.BridgeInterface

--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,7 @@ type Kubernetes struct {
 // Network is VM network configuration
 type Network struct {
 	Address         bool              `yaml:"address"`
+	Subnet          string            `yaml:"subnet,omitempty"`
 	DNSResolvers    []net.IP          `yaml:"dns"`
 	DNSHosts        map[string]string `yaml:"dnsHosts"`
 	HostAddresses   bool              `yaml:"hostAddresses"`

--- a/config/configmanager/configmanager.go
+++ b/config/configmanager/configmanager.go
@@ -3,6 +3,7 @@ package configmanager
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"strings"
 
@@ -97,11 +98,40 @@ func ValidateConfig(c config.Config) error {
 			return err
 		}
 	}
+	if err := validateNetworkSubnet(c); err != nil {
+		return err
+	}
 
 	if err := validateMounts(c.Mounts); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func validateNetworkSubnet(c config.Config) error {
+	if c.Network.Subnet == "" {
+		return nil
+	}
+	prefix, err := netip.ParsePrefix(c.Network.Subnet)
+	if err != nil {
+		return fmt.Errorf("invalid network subnet %q: %w", c.Network.Subnet, err)
+	}
+	if !prefix.Addr().Is4() {
+		return fmt.Errorf("network subnet %q is not IPv4", c.Network.Subnet)
+	}
+	if prefix.Bits() > 30 {
+		return fmt.Errorf("network subnet %q must contain at least two usable addresses", c.Network.Subnet)
+	}
+	if prefix != prefix.Masked() {
+		return fmt.Errorf("network subnet %q must use network address %q", c.Network.Subnet, prefix.Masked())
+	}
+	if c.Network.Mode != "shared" {
+		return fmt.Errorf("network subnet is only supported with shared network mode")
+	}
+	if c.VMType == "vz" {
+		return fmt.Errorf("network subnet is not supported with vmType 'vz'")
+	}
 	return nil
 }
 

--- a/config/configmanager/configmanager_test.go
+++ b/config/configmanager/configmanager_test.go
@@ -26,3 +26,91 @@ func TestValidateMounts(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNetworkSubnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  config.Config
+		wantErr bool
+	}{
+		{name: "unset"},
+		{
+			name: "QEMU shared",
+			config: config.Config{
+				VMType:  "qemu",
+				Network: config.Network{Mode: "shared", Subnet: "192.168.107.0/24"},
+			},
+		},
+		{
+			name: "Krunkit shared",
+			config: config.Config{
+				VMType:  "krunkit",
+				Network: config.Network{Mode: "shared", Subnet: "192.168.107.0/24"},
+			},
+		},
+		{
+			name: "VZ shared",
+			config: config.Config{
+				VMType:  "vz",
+				Network: config.Network{Mode: "shared", Subnet: "192.168.107.0/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bridged",
+			config: config.Config{
+				VMType:  "qemu",
+				Network: config.Network{Mode: "bridged", Subnet: "192.168.107.0/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid subnet",
+			config: config.Config{
+				VMType:  "qemu",
+				Network: config.Network{Mode: "shared", Subnet: "invalid"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing prefix length",
+			config: config.Config{
+				VMType:  "qemu",
+				Network: config.Network{Mode: "shared", Subnet: "192.168.107.0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "IPv6 subnet",
+			config: config.Config{
+				VMType:  "qemu",
+				Network: config.Network{Mode: "shared", Subnet: "fd00::/64"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "host address",
+			config: config.Config{
+				VMType:  "qemu",
+				Network: config.Network{Mode: "shared", Subnet: "192.168.107.10/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "not enough usable addresses",
+			config: config.Config{
+				VMType:  "qemu",
+				Network: config.Network{Mode: "shared", Subnet: "192.168.107.0/31"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateNetworkSubnet(tt.config); (err != nil) != tt.wantErr {
+				t.Errorf("validateNetworkSubnet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -100,9 +100,16 @@ func (l processManager) Start(ctx context.Context, conf config.Config) error {
 	args := []string{osutil.Executable(), "daemon", "start", config.CurrentProfile().ShortName}
 
 	if conf.Network.Address {
+		subnet, err := vmnet.ParseSubnet(conf.Network.Subnet)
+		if err != nil {
+			return err
+		}
 		args = append(args, "--vmnet")
 		args = append(args, "--vmnet-mode", conf.Network.Mode)
 		args = append(args, "--vmnet-interface", conf.Network.BridgeInterface)
+		args = append(args, "--vmnet-gateway", subnet.Gateway)
+		args = append(args, "--vmnet-dhcp-end", subnet.DHCPEnd)
+		args = append(args, "--vmnet-mask", subnet.Netmask)
 	}
 	if conf.MountINotify {
 		args = append(args, "--inotify")
@@ -134,7 +141,8 @@ func processesFromConfig(conf config.Config) []process.Process {
 	var processes []process.Process
 
 	if conf.Network.Address {
-		processes = append(processes, vmnet.New(conf.Network.Mode, conf.Network.BridgeInterface))
+		subnet, _ := vmnet.ParseSubnet(conf.Network.Subnet)
+		processes = append(processes, vmnet.New(conf.Network.Mode, conf.Network.BridgeInterface, subnet))
 	}
 	if conf.MountINotify {
 		processes = append(processes, inotify.New())

--- a/daemon/process/vmnet/vmnet.go
+++ b/daemon/process/vmnet/vmnet.go
@@ -2,8 +2,10 @@ package vmnet
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,20 +24,29 @@ const (
 
 	NetGateway = "192.168.106.1"
 	NetDHCPEnd = "192.168.106.254"
+	NetMask    = "255.255.255.0"
 )
 
 var _ process.Process = (*vmnetProcess)(nil)
 
-func New(mode, netInterface string) process.Process {
+func New(mode, netInterface string, subnet Subnet) process.Process {
 	return &vmnetProcess{
 		mode:         mode,
 		netInterface: netInterface,
+		subnet:       subnet,
 	}
+}
+
+type Subnet struct {
+	Gateway string
+	DHCPEnd string
+	Netmask string
 }
 
 type vmnetProcess struct {
 	mode         string
 	netInterface string
+	subnet       Subnet
 }
 
 func (*vmnetProcess) Alive(ctx context.Context) error {
@@ -95,8 +106,9 @@ func (v *vmnetProcess) Start(ctx context.Context) error {
 			command = cli.CommandInteractive("sudo", BinaryPath,
 				"--vmnet-mode", "shared",
 				"--socket-group", "staff",
-				"--vmnet-gateway", NetGateway,
-				"--vmnet-dhcp-end", NetDHCPEnd,
+				"--vmnet-gateway", v.subnet.Gateway,
+				"--vmnet-dhcp-end", v.subnet.DHCPEnd,
+				"--vmnet-mask", v.subnet.Netmask,
 				"--pidfile", pid,
 				socket,
 			)
@@ -122,6 +134,43 @@ func (v *vmnetProcess) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func ParseSubnet(value string) (Subnet, error) {
+	if value == "" {
+		return Subnet{
+			Gateway: NetGateway,
+			DHCPEnd: NetDHCPEnd,
+			Netmask: NetMask,
+		}, nil
+	}
+
+	prefix, err := netip.ParsePrefix(value)
+	if err != nil {
+		return Subnet{}, fmt.Errorf("invalid network subnet %q: %w", value, err)
+	}
+	if !prefix.Addr().Is4() {
+		return Subnet{}, fmt.Errorf("network subnet %q is not IPv4", value)
+	}
+	if prefix.Bits() > 30 {
+		return Subnet{}, fmt.Errorf("network subnet %q must contain at least two usable addresses", value)
+	}
+	if prefix != prefix.Masked() {
+		return Subnet{}, fmt.Errorf("network subnet %q must use network address %q", value, prefix.Masked())
+	}
+
+	addr := prefix.Addr().As4()
+	first := binary.BigEndian.Uint32(addr[:])
+	hostMask := uint32(1)<<(32-prefix.Bits()) - 1
+	var gateway, dhcpEnd [4]byte
+	binary.BigEndian.PutUint32(gateway[:], first+1)
+	binary.BigEndian.PutUint32(dhcpEnd[:], first+hostMask-1)
+
+	return Subnet{
+		Gateway: netip.AddrFrom4(gateway).String(),
+		DHCPEnd: netip.AddrFrom4(dhcpEnd).String(),
+		Netmask: net.IP(net.CIDRMask(prefix.Bits(), 32)).String(),
+	}, nil
 }
 
 func (vmnetProcess) Dependencies() (deps []process.Dependency, root bool) {

--- a/daemon/process/vmnet/vmnet_test.go
+++ b/daemon/process/vmnet/vmnet_test.go
@@ -1,0 +1,52 @@
+package vmnet
+
+import "testing"
+
+func TestParseSubnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    Subnet
+		wantErr bool
+	}{
+		{
+			name: "default",
+			want: Subnet{
+				Gateway: NetGateway,
+				DHCPEnd: NetDHCPEnd,
+				Netmask: NetMask,
+			},
+		},
+		{
+			name:  "custom",
+			value: "192.168.107.0/24",
+			want: Subnet{
+				Gateway: "192.168.107.1",
+				DHCPEnd: "192.168.107.254",
+				Netmask: "255.255.255.0",
+			},
+		},
+		{
+			name:  "small custom subnet",
+			value: "10.20.30.0/28",
+			want: Subnet{
+				Gateway: "10.20.30.1",
+				DHCPEnd: "10.20.30.14",
+				Netmask: "255.255.255.240",
+			},
+		},
+		{name: "invalid", value: "invalid", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSubnet(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseSubnet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseSubnet() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/embedded/defaults/colima.yaml
+++ b/embedded/defaults/colima.yaml
@@ -77,6 +77,11 @@ network:
   # Default: shared
   mode: shared
 
+  # Subnet to use for shared mode.
+  # This setting is not supported by VZ.
+  # Default: 192.168.106.0/24
+  subnet: ""
+
   # Network interface to use for bridged mode.
   # This is only used when mode is set to bridged.
   # NOTE: this is currently macOS only and ignored on Linux.

--- a/embedded/network/sudo.txt
+++ b/embedded/network/sudo.txt
@@ -1,5 +1,5 @@
 # starting vmnet daemon
-%staff ALL=(root:wheel) NOPASSWD:NOSETENV: /opt/colima/bin/socket_vmnet --vmnet-mode shared --socket-group staff --vmnet-gateway 192.168.106.1 --vmnet-dhcp-end 192.168.106.254 *
+%staff ALL=(root:wheel) NOPASSWD:NOSETENV: /opt/colima/bin/socket_vmnet --vmnet-mode shared --socket-group staff *
 %staff ALL=(root:wheel) NOPASSWD:NOSETENV: /opt/colima/bin/socket_vmnet --vmnet-mode bridged --socket-group staff *
 # terminating vmnet daemon
 %staff ALL=(root:wheel) NOPASSWD:NOSETENV: /usr/bin/pkill -F /opt/colima/run/*.pid

--- a/util/yamlutil/yaml_test.go
+++ b/util/yamlutil/yaml_test.go
@@ -11,8 +11,11 @@ import (
 
 func Test_encode_Docker(t *testing.T) {
 	conf := config.Config{
-		Docker:     map[string]any{"insecure-registries": []any{"127.0.0.1"}},
-		Network:    config.Network{DNSResolvers: []net.IP{net.ParseIP("1.1.1.1")}},
+		Docker: map[string]any{"insecure-registries": []any{"127.0.0.1"}},
+		Network: config.Network{
+			DNSResolvers: []net.IP{net.ParseIP("1.1.1.1")},
+			Subnet:       "192.168.107.0/24",
+		},
 		Kubernetes: config.Kubernetes{K3sArgs: []string{"--disable=traefik"}},
 	}
 
@@ -39,6 +42,9 @@ func Test_encode_Docker(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got.Docker, tt.want.Docker) {
 				t.Errorf("save() = %+v\nwant %+v", got.Docker, tt.want.Docker)
+			}
+			if got.Network.Subnet != tt.want.Network.Subnet {
+				t.Errorf("network subnet = %q, want %q", got.Network.Subnet, tt.want.Network.Subnet)
 			}
 		})
 	}


### PR DESCRIPTION
Add network.subnet and --network-subnet for QEMU and Krunkit shared networking while preserving the existing 192.168.106.0/24 default. Derive and pass the socket_vmnet gateway, DHCP end, and mask from the configured IPv4 CIDR.

Refs #573